### PR TITLE
feat: add scope motions, visual range select, argument swap, and mult…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,20 @@ One plugin replaces hop, leap, flash, and mini.jump — then goes further with t
 - 🔀 **Composable d/y/c/p** — `d` + any motion deletes, `y` + any motion yanks, `c` + any motion changes, with visual feedback at every step
 - ✂️ **Until motions** — `dt`, `yt`, `ct` operate from cursor to a labeled character on the current line
 - 📡 **Remote operations** — `rdw`, `rdl`, `ryw`, `ryl` delete or yank words and lines without moving the cursor
-- 🌳 **Treesitter-aware motions** — jump to functions (`]]`/`[[`), classes (`]c`/`[c`), delete/change/yank function names (`dfn`, `cfn`, `yfn`), and arguments (`daa`, `caa`, `yaa`)
+- 🌳 **Treesitter-aware motions** — jump to functions (`]]`/`[[`), classes (`]c`/`[c`), scopes/blocks (`]b`/`[b`), delete/change/yank function names (`dfn`, `cfn`, `yfn`), and arguments (`daa`, `caa`, `yaa`)
 - 🩺 **Diagnostics jumping** — navigate all diagnostics (`]d`/`[d`) or errors only (`]e`/`[e`)
 - 🔎 **2-char find** — `f`/`F` for leap-style two-character search with labels
 - 🔍 **Live search** — `s` for incremental search with labeled results across all visible text
+- 🎯 **Till motions** — `t`/`T` for single-character till (jump to just before/after the match), with `;`/`,` to repeat
+- 🔎 **Native search labels** — `<C-s>` during `/` search toggles label overlay on matches
 - 🪟 **Multi-window jumping** — search, treesitter, and diagnostic motions show labels across all visible splits. Select a label in another window and jump there instantly.
 - ⚙️ **Operator-pending mode** — use SmartMotion motions with any vim operator (`>w`, `gUw`, `=j`, `gqj`, etc.)
+- 👁️ **Visual range selection** — `gs` picks two targets, enters visual mode spanning the range
+- 🔄 **Argument swap** — `saa` picks two treesitter arguments and swaps them
+- ✏️ **Multi-cursor edit** — `gmd`/`gmy` toggle-select multiple words, then delete or yank them all at once
 - 🔁 **Repeat** — `.` repeats the last SmartMotion
 - 🧩 **Fully modular pipeline** — Collector → Extractor → Modifier → Filter → Visualizer → Selection → Action. Every stage is replaceable. Build entirely custom motions from scratch.
-- 📦 **10 presets, 40 keybindings** — enable what you want, disable what you don't
+- 📦 **10 presets, 50+ keybindings** — enable what you want, disable what you don't
 
 ---
 
@@ -51,14 +56,14 @@ return {
     presets = {
       words = true,        -- w, b, e, ge
       lines = true,        -- j, k
-      search = true,       -- s, f, F
+      search = true,       -- s, f, F, t, T, ;, ,, gs
       delete = true,       -- d, dt, dT, rdw, rdl
       yank = true,         -- y, yt, yT, ryw, ryl
       change = true,       -- c, ct, cT
       paste = true,        -- p, P
-      treesitter = true,   -- ]], [[, ]c, [c, daa, caa, yaa, dfn, cfn, yfn
+      treesitter = true,   -- ]], [[, ]c, [c, ]b, [b, daa, caa, yaa, dfn, cfn, yfn, saa
       diagnostics = true,  -- ]d, [d, ]e, [e
-      misc = true,         -- . (repeat)
+      misc = true,         -- . (repeat), gmd, gmy
     },
   },
 }
@@ -102,13 +107,18 @@ Every preset and its keybindings at a glance. Enable a preset and all its bindin
 </details>
 
 <details>
-<summary><b>🔍 Search</b> — <code>s</code> <code>f</code> <code>F</code> 🪟</summary>
+<summary><b>🔍 Search</b> — <code>s</code> <code>f</code> <code>F</code> <code>t</code> <code>T</code> <code>;</code> <code>,</code> <code>gs</code> 🪟</summary>
 
-| Key | Mode | Description                                          |
-|-----|------|------------------------------------------------------|
-| `s` | n, o | Live search across all visible text with labels      |
-| `f` | n, o | 2-char find forward with labels                      |
-| `F` | n, o | 2-char find backward with labels                     |
+| Key  | Mode | Description                                          |
+|------|------|------------------------------------------------------|
+| `s`  | n, o | Live search across all visible text with labels      |
+| `f`  | n, o | 2-char find forward with labels                      |
+| `F`  | n, o | 2-char find backward with labels                     |
+| `t`  | n, o | Till character forward (jump to just before match)   |
+| `T`  | n, o | Till character backward (jump to just after match)   |
+| `;`  | n, v | Repeat last f/F/t/T motion (same direction)          |
+| `,`  | n, v | Repeat last f/F/t/T motion (reversed direction)      |
+| `gs` | n    | Visual select via labels — pick two targets, enter visual mode |
 
 > Multi-window: labels appear in all visible splits.
 
@@ -162,7 +172,7 @@ Every preset and its keybindings at a glance. Enable a preset and all its bindin
 </details>
 
 <details>
-<summary><b>🌳 Treesitter</b> — <code>]]</code> <code>[[</code> <code>]c</code> <code>[c</code> <code>daa</code> <code>caa</code> <code>yaa</code> <code>dfn</code> <code>cfn</code> <code>yfn</code> 🪟</summary>
+<summary><b>🌳 Treesitter</b> — <code>]]</code> <code>[[</code> <code>]c</code> <code>[c</code> <code>]b</code> <code>[b</code> <code>daa</code> <code>caa</code> <code>yaa</code> <code>dfn</code> <code>cfn</code> <code>yfn</code> <code>saa</code> 🪟</summary>
 
 | Key   | Mode | Description                                   |
 |-------|------|-----------------------------------------------|
@@ -170,16 +180,19 @@ Every preset and its keybindings at a glance. Enable a preset and all its bindin
 | `[[`  | n, o | Jump to previous function                     |
 | `]c`  | n, o | Jump to next class/struct                     |
 | `[c`  | n, o | Jump to previous class/struct                 |
+| `]b`  | n, o | Jump to next block/scope (if, for, while, try, etc.) |
+| `[b`  | n, o | Jump to previous block/scope                  |
 | `daa` | n    | Delete around argument (includes separator)   |
 | `caa` | n    | Change argument                               |
 | `yaa` | n    | Yank argument                                 |
 | `dfn` | n    | Delete function name                          |
 | `cfn` | n    | Change function name (rename)                 |
 | `yfn` | n    | Yank function name                            |
+| `saa` | n    | Swap two arguments — pick two, swap their positions |
 
 Works across Lua, Python, JavaScript, TypeScript, Rust, Go, C, C++, Java, C#, and Ruby. Non-matching node types are safely ignored.
 
-> Multi-window: navigation motions (`]]`, `[[`, `]c`, `[c`) show labels across all visible splits. Editing motions stay in the current buffer.
+> Multi-window: navigation motions (`]]`, `[[`, `]c`, `[c`, `]b`, `[b`) show labels across all visible splits. Editing motions stay in the current buffer.
 
 </details>
 
@@ -198,11 +211,13 @@ Works across Lua, Python, JavaScript, TypeScript, Rust, Go, C, C++, Java, C#, an
 </details>
 
 <details>
-<summary><b>🔁 Misc</b> — <code>.</code></summary>
+<summary><b>🔁 Misc</b> — <code>.</code> <code>gmd</code> <code>gmy</code></summary>
 
-| Key | Mode | Description            |
-|-----|------|------------------------|
-| `.` | n    | Repeat last SmartMotion |
+| Key   | Mode | Description                                          |
+|-------|------|------------------------------------------------------|
+| `.`   | n    | Repeat last SmartMotion                               |
+| `gmd` | n    | Multi-cursor delete — toggle-select words, press Enter to delete all |
+| `gmy` | n    | Multi-cursor yank — toggle-select words, press Enter to yank all    |
 
 </details>
 
@@ -236,7 +251,7 @@ gqj   — format from cursor to labeled line
 >]]   — indent from cursor to labeled function
 ```
 
-All jump-only motions (`w`, `b`, `e`, `ge`, `j`, `k`, `s`, `f`, `F`, `]]`, `[[`, `]c`, `[c`, `]d`, `[d`, `]e`, `[e`) are available in operator-pending mode. SmartMotion's own operators (`d`, `y`, `c`, `p`, `P`) are not — they handle operators internally via inference.
+All jump-only motions (`w`, `b`, `e`, `ge`, `j`, `k`, `s`, `f`, `F`, `t`, `T`, `]]`, `[[`, `]c`, `[c`, `]b`, `[b`, `]d`, `[d`, `]e`, `[e`) are available in operator-pending mode. SmartMotion's own operators (`d`, `y`, `c`, `p`, `P`) and standalone actions (`gs`, `saa`, `gmd`, `gmy`) are not — they handle operations internally.
 
 ---
 
@@ -245,8 +260,8 @@ All jump-only motions (`w`, `b`, `e`, `ge`, `j`, `k`, `s`, `f`, `F`, `]]`, `[[`,
 Search, treesitter navigation, and diagnostic motions collect targets from **all visible splits** — not just the current window. Labels from the current window get priority (closer targets get single-character labels), and selecting a label in another window jumps your cursor there.
 
 Enabled by default for:
-- **Search**: `s`, `f`, `F`
-- **Treesitter navigation**: `]]`, `[[`, `]c`, `[c`
+- **Search**: `s`, `f`, `F`, `t`, `T`, `;`, `,`, `gs`
+- **Treesitter navigation**: `]]`, `[[`, `]c`, `[c`, `]b`, `[b`
 - **Diagnostics**: `]d`, `[d`, `]e`, `[e`
 
 Word and line motions (`w`, `b`, `e`, `ge`, `j`, `k`) stay single-window — directional motions within one window are the natural UX.
@@ -353,6 +368,9 @@ Full default configuration:
 
   -- Automatically select when only one target exists
   auto_select_target = false,
+
+  -- Enable label overlay during native / search (toggle with <C-s>)
+  native_search = true,
 }
 ```
 
@@ -369,6 +387,7 @@ Highlight values accept either a string (existing highlight group name) or a tab
 | `dim` | `SmartMotionDim` | Backdrop for non-target text |
 | `search_prefix` | `SmartMotionSearchPrefix` | Search prefix label |
 | `search_prefix_dim` | `SmartMotionSearchPrefixDim` | Dimmed search prefix |
+| `selected` | `SmartMotionSelected` | Multi-cursor selected target |
 
 ```lua
 highlight = {

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -42,7 +42,7 @@ gq]]  — format from cursor to labeled function
 
 ### Which motions support it?
 
-All jump-only motions: `w`, `b`, `e`, `ge`, `j`, `k`, `s`, `f`, `F`, `]]`, `[[`, `]c`, `[c`, `]d`, `[d`, `]e`, `[e`.
+All jump-only motions: `w`, `b`, `e`, `ge`, `j`, `k`, `s`, `f`, `F`, `t`, `T`, `]]`, `[[`, `]c`, `[c`, `]b`, `[b`, `]d`, `[d`, `]e`, `[e`.
 
 SmartMotion's own operators (`d`, `y`, `c`, `p`, `P`) and composites (`dt`, `yt`, `ct`, `daa`, `cfn`, etc.) are **not** registered in `"o"` mode — they handle operations internally via the inference system.
 
@@ -82,6 +82,96 @@ sm.motions.register("my_search", {
   trigger = "<leader>s",
 })
 ```
+
+---
+
+## 🎯 Till Motions & Char Repeat
+
+### t/T — Till Character
+
+`t` and `T` are single-character "till" motions. They prompt for one character, then label all matches — but the jump lands just **before** (for `t`) or just **after** (for `T`) the matched character rather than on it.
+
+- `t` → forward: cursor lands at `col - 1` of the match
+- `T` → backward: cursor lands at `col + 1` of the match
+
+Both work in normal and operator-pending mode. In operator-pending mode, `dt` deletes from cursor to just before the character — matching native vim behavior.
+
+### ;/, — Repeat Last Char Motion
+
+After any `f`/`F`/`t`/`T` motion, the last search state (text, direction, exclude_target) is saved. Press `;` to repeat in the same direction, `,` to repeat in the reversed direction.
+
+Both `;` and `,` show labels across all visible windows for selection — they don't just jump to the next match like native vim. This gives you full control over which match to jump to.
+
+---
+
+## 🔎 Native Search Labels
+
+When `native_search` is enabled (default), SmartMotion enhances vim's built-in `/` search:
+
+1. Press `/` and start typing — incremental match highlights appear in real-time
+2. Press Enter to close the search prompt
+3. Labels appear on all visible matches — pick one to jump there instantly
+4. Press `<C-s>` during search to toggle the label overlay on/off
+
+This is disabled in operator-pending mode (since operators need native search behavior). Configure via:
+
+```lua
+opts = {
+  native_search = true,  -- default: enabled
+}
+```
+
+---
+
+## 🌳 Scope-Aware Motions
+
+`]b` and `[b` jump to block/scope boundaries — control flow, loops, exception handling, and closures:
+
+- **Control flow**: `if`, `switch`, `match`, `case`, `else`, `elif`
+- **Loops**: `for`, `while`, `do`, `repeat`, `loop`
+- **Exception handling**: `try`, `catch`, `except`, `finally`
+- **Blocks/closures**: `block`, `lambda`, `closure`, `with`, `do_block`
+
+These work across all languages with treesitter support. Labels appear in all visible windows. Available in both normal and operator-pending mode.
+
+---
+
+## 👁️ Visual Range Selection
+
+`gs` lets you pick two word targets and enters visual mode spanning the range:
+
+1. Press `gs` — labels appear on all visible words (across windows)
+2. Pick the first target — it highlights while labels re-render for the second pick
+3. Pick the second target — visual mode activates from the first to the second position
+
+If the two targets are in different order, they're automatically sorted so the selection goes from earlier to later. If the first target is in a different window, the cursor switches to that window.
+
+---
+
+## 🔄 Argument Swap
+
+`saa` picks two treesitter arguments and swaps their text:
+
+1. Press `saa` — labels appear on all function/method arguments in the current buffer
+2. Pick the first argument — it highlights while labels re-render
+3. Pick the second argument — both arguments swap positions
+
+The swap replaces the later position first to avoid offset corruption. Works with any language that has treesitter support for argument/parameter lists.
+
+---
+
+## ✏️ Multi-Cursor Edit
+
+`gmd` (delete) and `gmy` (yank) provide toggle-based multi-selection:
+
+1. Press `gmd` or `gmy` — labels appear on all visible words
+2. Press label keys to **toggle** targets on/off — selected targets turn green (`SmartMotionSelected`)
+3. Press **Enter** to confirm, **ESC** to cancel
+4. Action executes on all selected targets:
+   - `gmd`: deletes each selected word (processed bottom-to-top for position stability)
+   - `gmy`: yanks all selected words into the `"` register (newline-separated, in document order)
+
+Double-character labels work too — press the first character, then the second to toggle that target.
 
 ---
 
@@ -141,6 +231,7 @@ SmartMotion allows full control over highlight groups. You can change foreground
 | `second_char`     | SmartMotionSecondChar    | Brighter second label character      |
 | `second_char_dim` | SmartMotionSecondCharDim | Dimmed second label character        |
 | `dim`             | SmartMotionDim           | Background dim when not in selection |
+| `selected`        | SmartMotionSelected      | Multi-cursor selected target (green) |
 
 ### Setting Custom Highlights
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -25,6 +25,8 @@ local default_config = {
   flow_state_timeout_ms = 300,
   disable_dim_background = false,
   history_max_size = 20,
+  auto_select_target = false,
+  native_search = true, -- label overlay during / search (toggle with <C-s>)
 }
 ```
 

--- a/docs/defaults.md
+++ b/docs/defaults.md
@@ -111,14 +111,14 @@ The following presets are available:
 | ------------- | -------------------------------------------------------- |
 | `words`       | Motions for `w`, `b`, `e`, `ge`                          |
 | `lines`       | Motions for `j`, `k`                                     |
-| `search`      | Motions for `f`, `F`, `s`, `S`                           |
+| `search`      | Motions for `s`, `f`, `F`, `t`, `T`, `;`, `,`, `gs`     |
 | `delete`      | Delete motions: `d`, `dt`, `dT`, `rdw`, `rdl`           |
 | `yank`        | Yank motions: `y`, `yt`, `yT`, `ryw`, `ryl`             |
 | `change`      | Change motions: `c`, `ct`, `cT`                          |
 | `paste`       | Paste motions: `p`, `P`                                  |
-| `treesitter`  | Navigation (`]]`, `[[`, `]c`, `[c`) and editing (`daa`, `caa`, `yaa`, `dfn`, `cfn`, `yfn`) |
+| `treesitter`  | Navigation (`]]`, `[[`, `]c`, `[c`, `]b`, `[b`) and editing (`daa`, `caa`, `yaa`, `dfn`, `cfn`, `yfn`, `saa`) |
 | `diagnostics` | Diagnostic jumping: `]d`, `[d`, `]e`, `[e`              |
-| `misc`        | Repeat previous motion with `.`                          |
+| `misc`        | Repeat (`.`), multi-cursor delete (`gmd`), multi-cursor yank (`gmy`) |
 
 See [`presets.md`](./presets.md) for the full breakdown of mappings and behavior.
 

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -26,11 +26,19 @@ This reference documents all the motions included in the default SmartMotion pre
 
 ## Preset: `search`
 
-| Key | Mode | Multi-window | Description                                     |
-| --- | ---- | ------------ | ----------------------------------------------- |
-| `s` | n, o | yes          | Live search across all visible text with labels |
-| `f` | n, o | yes          | 2 Character Find After Cursor                   |
-| `F` | n, o | yes          | 2 Character Find Before Cursor                  |
+| Key  | Mode | Multi-window | Description                                          |
+| ---- | ---- | ------------ | ---------------------------------------------------- |
+| `s`  | n, o | yes          | Live search across all visible text with labels      |
+| `f`  | n, o | yes          | 2 Character Find After Cursor                        |
+| `F`  | n, o | yes          | 2 Character Find Before Cursor                       |
+| `t`  | n, o | yes          | Till Character After Cursor (jump to just before)    |
+| `T`  | n, o | yes          | Till Character Before Cursor (jump to just after)    |
+| `;`  | n, v | yes          | Repeat last f/F/t/T motion (same direction)          |
+| `,`  | n, v | yes          | Repeat last f/F/t/T motion (reversed direction)      |
+| `gs` | n    | yes          | Visual select via labels — pick two words, enter visual mode |
+
+> [!NOTE]
+> `;` and `,` use literal matching and show labels across all visible windows. `gs` uses dual selection (pick start, then end) and works across windows.
 
 ---
 
@@ -87,6 +95,8 @@ This reference documents all the motions included in the default SmartMotion pre
 | `[[` | n, o | yes          | Jump to previous function definition before cursor   |
 | `]c` | n, o | yes          | Jump to next class/struct definition after cursor    |
 | `[c` | n, o | yes          | Jump to previous class/struct definition before cursor |
+| `]b` | n, o | yes          | Jump to next block/scope (if, for, while, try, etc.) |
+| `[b` | n, o | yes          | Jump to previous block/scope                         |
 
 ### Editing
 
@@ -98,9 +108,13 @@ This reference documents all the motions included in the default SmartMotion pre
 | `dfn` | n    | Delete function name                            |
 | `cfn` | n    | Change function name (rename)                   |
 | `yfn` | n    | Yank function name                              |
+| `saa` | n    | Swap two arguments — pick two with labels, swap positions |
 
 > [!NOTE]
 > Treesitter presets use broad node type lists that work across many languages (Lua, Python, JavaScript, TypeScript, Rust, Go, C/C++, Java, Ruby). Non-matching types are safely ignored.
+
+> [!NOTE]
+> `saa` (swap) uses dual selection: press to see labels on all arguments, pick the first argument, labels re-render for the second pick, then both arguments swap positions. The later position is replaced first for buffer stability.
 
 ---
 
@@ -117,9 +131,14 @@ This reference documents all the motions included in the default SmartMotion pre
 
 ## Preset: `misc`
 
-| Key | Description                |
-| --- | -------------------------- |
-| `.` | Repeat the previous motion |
+| Key   | Description                                                        |
+| ----- | ------------------------------------------------------------------ |
+| `.`   | Repeat the previous motion                                         |
+| `gmd` | Multi-cursor delete — toggle-select multiple words, Enter to delete |
+| `gmy` | Multi-cursor yank — toggle-select multiple words, Enter to yank     |
+
+> [!NOTE]
+> `gmd` and `gmy` use multi-selection mode: labels appear on all visible words. Press a label key to toggle it on/off (selected targets highlight green). Press Enter to confirm, ESC to cancel. Targets are processed in reverse position order for safe sequential editing.
 
 ---
 
@@ -131,7 +150,7 @@ This reference documents all the motions included in the default SmartMotion pre
 | ---- | ----------- |
 | `n`  | Normal mode |
 | `v`  | Visual mode |
-| `o`  | Operator-pending mode — works with any vim operator (`>`, `<`, `gU`, `gu`, `=`, `gq`, `!`, `zf`, etc.) |
+| `o`  | Operator-pending mode — works with any vim operator (`>`, `<`, `gU`, `gu`, `=`, `gq`, `!`, `zf`, etc.). Available for all jump motions including `t`/`T` and `]b`/`[b`. |
 
 > [!NOTE]
 > In operator-pending mode, SmartMotion performs a plain jump (no centering) so the operator receives the cursor movement correctly. Multi-window is disabled in operator-pending mode since vim operators expect movement within the same buffer.

--- a/lua/smart-motion/actions/multi_edit.lua
+++ b/lua/smart-motion/actions/multi_edit.lua
@@ -1,0 +1,123 @@
+--- Multi-cursor edit: select multiple word targets, then delete or yank them all.
+--- Triggered by `gmd` (delete) or `gmy` (yank).
+local consts = require("smart-motion.consts")
+
+local M = {}
+
+--- Collects word targets across visible lines in all windows.
+---@param ctx SmartMotionContext
+---@return table[]
+function M._collect_word_targets(ctx)
+	local targets = {}
+	local pattern = consts.WORD_PATTERN
+
+	for _, win in ipairs(ctx.windows) do
+		local winid = win.winid
+		local bufnr = win.bufnr
+
+		if not vim.api.nvim_buf_is_valid(bufnr) then
+			goto continue
+		end
+
+		local top_line = vim.fn.line("w0", winid) - 1
+		local bottom_line = vim.fn.line("w$", winid) - 1
+		local lines = vim.api.nvim_buf_get_lines(bufnr, top_line, bottom_line + 1, false)
+
+		for i, line_text in ipairs(lines) do
+			local line_number = top_line + i - 1
+			local col = 0
+
+			while true do
+				local ok, match_data = pcall(vim.fn.matchstrpos, line_text, pattern, col)
+				if not ok then
+					break
+				end
+
+				local match, start_col, end_col = match_data[1], match_data[2], match_data[3]
+				if start_col == -1 then
+					break
+				end
+
+				table.insert(targets, {
+					text = match,
+					start_pos = { row = line_number, col = start_col },
+					end_pos = { row = line_number, col = end_col },
+					type = "words",
+					metadata = { bufnr = bufnr, winid = winid },
+				})
+
+				col = end_col + 1
+			end
+		end
+
+		::continue::
+	end
+
+	return targets
+end
+
+--- Runs multi-cursor edit: show labels, toggle-select multiple, then act.
+---@param action_type "delete"|"yank"
+function M.run(action_type)
+	local context = require("smart-motion.core.context")
+	local state = require("smart-motion.core.state")
+	local highlight = require("smart-motion.core.highlight")
+	local hints = require("smart-motion.visualizers.hints")
+	local multi_selection = require("smart-motion.core.multi_selection")
+	local cfg_mod = require("smart-motion.config")
+
+	local cfg = cfg_mod.validated
+	if not cfg then
+		return
+	end
+
+	local ctx = context.get()
+	local motion_state = state.create_motion_state()
+	motion_state.multi_window = true
+
+	local targets = M._collect_word_targets(ctx)
+	if #targets == 0 then
+		return
+	end
+
+	motion_state.jump_targets = targets
+	state.finalize_motion_state(ctx, cfg, motion_state)
+
+	-- Show initial hints
+	hints.run(ctx, cfg, motion_state)
+
+	-- Multi-selection loop (toggle labels, Enter to confirm, ESC to cancel)
+	local selected = multi_selection.wait_for_multi_selection(ctx, cfg, motion_state)
+
+	highlight.clear(ctx, cfg, motion_state)
+	vim.cmd("redraw")
+
+	if not selected or #selected == 0 then
+		return
+	end
+
+	if action_type == "delete" then
+		-- Delete each selected target (reverse order for position stability)
+		for _, target in ipairs(selected) do
+			local bufnr = (target.metadata and target.metadata.bufnr) or ctx.bufnr
+			vim.api.nvim_buf_set_text(bufnr,
+				target.start_pos.row, target.start_pos.col,
+				target.end_pos.row, target.end_pos.col, { "" })
+		end
+	elseif action_type == "yank" then
+		-- Collect all selected texts and yank them (newline-separated)
+		-- Targets are in reverse order, so reverse to get natural order for yank
+		local texts = {}
+		for i = #selected, 1, -1 do
+			local target = selected[i]
+			local bufnr = (target.metadata and target.metadata.bufnr) or ctx.bufnr
+			local text = vim.api.nvim_buf_get_text(bufnr,
+				target.start_pos.row, target.start_pos.col,
+				target.end_pos.row, target.end_pos.col, {})
+			table.insert(texts, table.concat(text, "\n"))
+		end
+		vim.fn.setreg('"', table.concat(texts, "\n"))
+	end
+end
+
+return M

--- a/lua/smart-motion/actions/swap.lua
+++ b/lua/smart-motion/actions/swap.lua
@@ -1,0 +1,129 @@
+--- Argument swap via dual label picks.
+--- Triggered by `saa`: pick two arguments, swap their text.
+local M = {}
+
+-- Same container types used by daa/caa/yaa
+local arg_container_types = {
+	"arguments",
+	"argument_list",
+	"parameters",
+	"parameter_list",
+	"formal_parameters",
+}
+
+--- Collects treesitter argument children from the current buffer.
+---@param ctx SmartMotionContext
+---@return table[]
+function M._collect_ts_targets(ctx)
+	local log = require("smart-motion.core.log")
+	local targets = {}
+	local bufnr = ctx.bufnr
+
+	local ok, parser = pcall(vim.treesitter.get_parser, bufnr)
+	if not ok or not parser then
+		log.debug("Treesitter parser not available for buffer " .. tostring(bufnr))
+		return targets
+	end
+
+	local trees = parser:parse()
+	if not trees or not trees[1] then
+		return targets
+	end
+
+	local root = trees[1]:root()
+
+	-- Walk tree to find argument containers
+	local containers = {}
+	local function walk_tree(node)
+		if vim.tbl_contains(arg_container_types, node:type()) then
+			table.insert(containers, node)
+		end
+		for child in node:iter_children() do
+			walk_tree(child)
+		end
+	end
+	walk_tree(root)
+
+	-- Yield named children of each container (individual arguments)
+	for _, container in ipairs(containers) do
+		for child in container:iter_children() do
+			if child:named() then
+				local sr, sc, er, ec = child:range()
+				local text = vim.api.nvim_buf_get_text(bufnr, sr, sc, er, ec, {})
+
+				table.insert(targets, {
+					text = table.concat(text, "\n"),
+					start_pos = { row = sr, col = sc },
+					end_pos = { row = er, col = ec },
+					type = "treesitter",
+					metadata = {
+						bufnr = bufnr,
+						winid = ctx.winid,
+						node_type = child:type(),
+						parent_type = container:type(),
+					},
+				})
+			end
+		end
+	end
+
+	return targets
+end
+
+--- Runs argument swap: pick two arguments, swap their text.
+function M.run()
+	local context = require("smart-motion.core.context")
+	local state = require("smart-motion.core.state")
+	local highlight = require("smart-motion.core.highlight")
+	local dual_selection = require("smart-motion.core.dual_selection")
+	local cfg_mod = require("smart-motion.config")
+
+	local cfg = cfg_mod.validated
+	if not cfg then
+		return
+	end
+
+	local ctx = context.get()
+	local motion_state = state.create_motion_state()
+
+	local targets = M._collect_ts_targets(ctx)
+	if #targets < 2 then
+		return
+	end
+
+	motion_state.jump_targets = targets
+	state.finalize_motion_state(ctx, cfg, motion_state)
+
+	local first, second = dual_selection.run(ctx, cfg, motion_state)
+
+	if not first or not second then
+		highlight.clear(ctx, cfg, motion_state)
+		vim.cmd("redraw")
+		return
+	end
+
+	-- Read text from both targets
+	local first_text = vim.api.nvim_buf_get_text(
+		ctx.bufnr, first.start_pos.row, first.start_pos.col,
+		first.end_pos.row, first.end_pos.col, {})
+	local second_text = vim.api.nvim_buf_get_text(
+		ctx.bufnr, second.start_pos.row, second.start_pos.col,
+		second.end_pos.row, second.end_pos.col, {})
+
+	-- Order: a is earlier, b is later (replace later first for position stability)
+	local a, b = first, second
+	local a_text, b_text = first_text, second_text
+	if a.start_pos.row > b.start_pos.row
+		or (a.start_pos.row == b.start_pos.row and a.start_pos.col > b.start_pos.col) then
+		a, b = b, a
+		a_text, b_text = b_text, a_text
+	end
+
+	-- Replace b (later position) with a's text, then a (earlier position) with b's text
+	vim.api.nvim_buf_set_text(ctx.bufnr,
+		b.start_pos.row, b.start_pos.col, b.end_pos.row, b.end_pos.col, a_text)
+	vim.api.nvim_buf_set_text(ctx.bufnr,
+		a.start_pos.row, a.start_pos.col, a.end_pos.row, a.end_pos.col, b_text)
+end
+
+return M

--- a/lua/smart-motion/actions/visual_select.lua
+++ b/lua/smart-motion/actions/visual_select.lua
@@ -1,0 +1,111 @@
+--- Visual range selection via dual label picks.
+--- Triggered by `gs`: pick two word targets, enter visual mode spanning the range.
+local consts = require("smart-motion.consts")
+
+local M = {}
+
+--- Collects word targets across visible lines in all windows.
+---@param ctx SmartMotionContext
+---@return table[]
+function M._collect_word_targets(ctx)
+	local targets = {}
+	local pattern = consts.WORD_PATTERN
+
+	for _, win in ipairs(ctx.windows) do
+		local winid = win.winid
+		local bufnr = win.bufnr
+
+		if not vim.api.nvim_buf_is_valid(bufnr) then
+			goto continue
+		end
+
+		local top_line = vim.fn.line("w0", winid) - 1
+		local bottom_line = vim.fn.line("w$", winid) - 1
+		local lines = vim.api.nvim_buf_get_lines(bufnr, top_line, bottom_line + 1, false)
+
+		for i, line_text in ipairs(lines) do
+			local line_number = top_line + i - 1
+			local col = 0
+
+			while true do
+				local ok, match_data = pcall(vim.fn.matchstrpos, line_text, pattern, col)
+				if not ok then
+					break
+				end
+
+				local match, start_col, end_col = match_data[1], match_data[2], match_data[3]
+				if start_col == -1 then
+					break
+				end
+
+				table.insert(targets, {
+					text = match,
+					start_pos = { row = line_number, col = start_col },
+					end_pos = { row = line_number, col = end_col },
+					type = "words",
+					metadata = { bufnr = bufnr, winid = winid },
+				})
+
+				col = end_col + 1
+			end
+		end
+
+		::continue::
+	end
+
+	return targets
+end
+
+--- Runs visual range selection: pick two targets, enter visual mode.
+function M.run()
+	local context = require("smart-motion.core.context")
+	local state = require("smart-motion.core.state")
+	local highlight = require("smart-motion.core.highlight")
+	local dual_selection = require("smart-motion.core.dual_selection")
+	local cfg_mod = require("smart-motion.config")
+
+	local cfg = cfg_mod.validated
+	if not cfg then
+		return
+	end
+
+	local ctx = context.get()
+	local motion_state = state.create_motion_state()
+	motion_state.multi_window = true
+
+	local targets = M._collect_word_targets(ctx)
+	if #targets == 0 then
+		return
+	end
+
+	motion_state.jump_targets = targets
+	state.finalize_motion_state(ctx, cfg, motion_state)
+
+	local first, second = dual_selection.run(ctx, cfg, motion_state)
+
+	if not first or not second then
+		highlight.clear(ctx, cfg, motion_state)
+		vim.cmd("redraw")
+		return
+	end
+
+	-- Order: ensure first is before second positionally
+	if first.start_pos.row > second.start_pos.row
+		or (first.start_pos.row == second.start_pos.row
+			and first.start_pos.col > second.start_pos.col) then
+		first, second = second, first
+	end
+
+	-- Switch to first target's window if needed
+	local winid = first.metadata and first.metadata.winid or ctx.winid
+	if winid ~= vim.api.nvim_get_current_win() then
+		vim.api.nvim_set_current_win(winid)
+	end
+
+	-- Set cursor to start, enter visual, extend to end
+	vim.api.nvim_win_set_cursor(winid, { first.start_pos.row + 1, first.start_pos.col })
+	vim.cmd("normal! v")
+	vim.api.nvim_win_set_cursor(winid, { second.end_pos.row + 1, math.max(second.end_pos.col - 1, 0) })
+end
+
+return M

--- a/lua/smart-motion/core/dual_selection.lua
+++ b/lua/smart-motion/core/dual_selection.lua
@@ -1,0 +1,82 @@
+--- Shared helper for features needing two sequential label picks.
+--- Used by visual range selection and argument swap.
+local consts = require("smart-motion.consts")
+local state = require("smart-motion.core.state")
+local highlight = require("smart-motion.core.highlight")
+local hints = require("smart-motion.visualizers.hints")
+local selection = require("smart-motion.core.selection")
+
+local M = {}
+
+--- Runs two rounds of label selection on the same target set.
+--- Returns (first, second) or (nil, nil) on cancel.
+---@param ctx SmartMotionContext
+---@param cfg SmartMotionConfig
+---@param motion_state SmartMotionMotionState
+---@param opts? { filter_second?: fun(targets: table[], first: table): table[] }
+---@return table|nil, table|nil
+function M.run(ctx, cfg, motion_state, opts)
+	-- Round 1: show labels and let user pick first target
+	hints.run(ctx, cfg, motion_state)
+	selection.wait_for_hint_selection(ctx, cfg, motion_state)
+
+	if not motion_state.selected_jump_target then
+		highlight.clear(ctx, cfg, motion_state)
+		vim.cmd("redraw")
+		return nil, nil
+	end
+
+	local first = vim.deepcopy(motion_state.selected_jump_target)
+
+	-- Save all targets before reset
+	local all_targets = motion_state.jump_targets
+
+	-- Reset selection state for round 2
+	highlight.clear(ctx, cfg, motion_state)
+	state.reset(motion_state)
+
+	-- Filter targets for round 2
+	local remaining
+	if opts and opts.filter_second then
+		remaining = opts.filter_second(all_targets, first)
+	else
+		remaining = vim.tbl_filter(function(t)
+			return not (t.start_pos.row == first.start_pos.row
+				and t.start_pos.col == first.start_pos.col
+				and t.end_pos.row == first.end_pos.row
+				and t.end_pos.col == first.end_pos.col)
+		end, all_targets)
+	end
+
+	if #remaining == 0 then
+		vim.cmd("redraw")
+		return first, nil
+	end
+
+	motion_state.jump_targets = remaining
+	state.finalize_motion_state(ctx, cfg, motion_state)
+
+	-- Highlight first pick so user sees what they selected
+	local first_bufnr = first.metadata and first.metadata.bufnr or ctx.bufnr
+	vim.api.nvim_buf_set_extmark(first_bufnr, consts.ns_id, first.start_pos.row, first.start_pos.col, {
+		end_col = first.end_pos.col,
+		hl_group = cfg.highlight.hint or "SmartMotionHint",
+	})
+	motion_state.affected_buffers = motion_state.affected_buffers or {}
+	motion_state.affected_buffers[first_bufnr] = true
+
+	-- Round 2: show labels on remaining targets
+	hints.run(ctx, cfg, motion_state)
+	selection.wait_for_hint_selection(ctx, cfg, motion_state)
+
+	local second = motion_state.selected_jump_target
+		and vim.deepcopy(motion_state.selected_jump_target)
+		or nil
+
+	highlight.clear(ctx, cfg, motion_state)
+	vim.cmd("redraw")
+
+	return first, second
+end
+
+return M

--- a/lua/smart-motion/core/multi_selection.lua
+++ b/lua/smart-motion/core/multi_selection.lua
@@ -1,0 +1,144 @@
+--- Multi-selection mode: toggle multiple targets with label keys, confirm with Enter.
+local consts = require("smart-motion.consts")
+local highlight = require("smart-motion.core.highlight")
+local log = require("smart-motion.core.log")
+
+local M = {}
+
+--- Redraws hints with selected targets highlighted differently.
+---@param ctx SmartMotionContext
+---@param cfg SmartMotionConfig
+---@param motion_state SmartMotionMotionState
+---@param selected table<string, boolean>
+function M._redraw_with_selections(ctx, cfg, motion_state, selected)
+	highlight.clear(ctx, cfg, motion_state)
+	highlight.dim_background(ctx, cfg, motion_state)
+
+	local targets = motion_state.jump_targets or {}
+	local label_pool = motion_state.hint_labels or {}
+
+	for index, target in ipairs(targets) do
+		local label = label_pool[index]
+		if not label or not target then
+			break
+		end
+
+		if selected[label] then
+			-- Selected: use SmartMotionSelected highlight via extmark
+			local bufnr = (target.metadata and target.metadata.bufnr) or ctx.bufnr
+			motion_state.affected_buffers = motion_state.affected_buffers or {}
+			motion_state.affected_buffers[bufnr] = true
+
+			local row = target.start_pos.row
+			local col = target.start_pos.col
+			local end_col = target.end_pos.col
+
+			-- Clamp col to line length
+			local line_text = vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1]
+			if line_text then
+				col = math.min(col, #line_text)
+				end_col = math.min(end_col, #line_text)
+			end
+
+			-- Highlight the selected target text
+			vim.api.nvim_buf_set_extmark(bufnr, consts.ns_id, row, col, {
+				end_col = end_col,
+				hl_group = "SmartMotionSelected",
+			})
+
+			-- Also show the label overlaid
+			vim.api.nvim_buf_set_extmark(bufnr, consts.ns_id, row, col, {
+				virt_text = { { label, "SmartMotionSelected" } },
+				virt_text_pos = "overlay",
+				hl_mode = "combine",
+			})
+		else
+			-- Not selected: render normal hint
+			if #label == 1 then
+				highlight.apply_single_hint_label(ctx, cfg, motion_state, target, label)
+			elseif #label == 2 then
+				highlight.apply_double_hint_label(ctx, cfg, motion_state, target, label)
+			end
+		end
+	end
+
+	vim.cmd("redraw")
+end
+
+--- Waits for user to toggle multiple targets via label keys.
+--- Enter confirms, ESC cancels.
+---@param ctx SmartMotionContext
+---@param cfg SmartMotionConfig
+---@param motion_state SmartMotionMotionState
+---@return table[]|nil Selected targets sorted in reverse position order, or nil on cancel.
+function M.wait_for_multi_selection(ctx, cfg, motion_state)
+	local selected = {} -- label → true toggle map
+
+	while true do
+		local char = vim.fn.getcharstr()
+
+		-- ESC cancels
+		if char == "\027" or char == "" then
+			return nil
+		end
+
+		-- Enter confirms
+		if char == "\r" then
+			break
+		end
+
+		local entry = motion_state.assigned_hint_labels[char]
+
+		if entry and entry.is_single_prefix and entry.target then
+			-- Toggle single-char label
+			if selected[char] then
+				selected[char] = nil
+			else
+				selected[char] = true
+			end
+			M._redraw_with_selections(ctx, cfg, motion_state, selected)
+		elseif entry and entry.is_double_prefix then
+			-- Wait for second char
+			local char2 = vim.fn.getcharstr()
+			if char2 == "\027" or char2 == "" then
+				return nil
+			end
+
+			local full = char .. char2
+			local entry2 = motion_state.assigned_hint_labels[full]
+			if entry2 and entry2.target then
+				if selected[full] then
+					selected[full] = nil
+				else
+					selected[full] = true
+				end
+				M._redraw_with_selections(ctx, cfg, motion_state, selected)
+			end
+		end
+	end
+
+	-- Collect selected targets
+	local selected_targets = {}
+	for label, _ in pairs(selected) do
+		local entry = motion_state.assigned_hint_labels[label]
+		if entry and entry.target then
+			table.insert(selected_targets, entry.target)
+		end
+	end
+
+	if #selected_targets == 0 then
+		return nil
+	end
+
+	-- Sort reverse (bottom-right first) for safe sequential editing
+	table.sort(selected_targets, function(a, b)
+		if a.start_pos.row ~= b.start_pos.row then
+			return a.start_pos.row > b.start_pos.row
+		end
+		return a.start_pos.col > b.start_pos.col
+	end)
+
+	return selected_targets
+end
+
+return M

--- a/lua/smart-motion/highlight_setup.lua
+++ b/lua/smart-motion/highlight_setup.lua
@@ -11,6 +11,7 @@ local default_highlights = {
 	SmartMotionDim = { fg = "#555555", bg = "none" },
 	SmartMotionSearchPrefix = { fg = "#BBBBBB", bg = "none" },
 	SmartMotionSearchPrefixDim = { fg = "#888888", bg = "none" },
+	SmartMotionSelected = { fg = "#FAFAFA", bg = "#2FD070", bold = true },
 }
 
 local background_highlights = {
@@ -21,6 +22,7 @@ local background_highlights = {
 	SmartMotionDim = { fg = "#555555", bg = "none" },
 	SmartMotionSearchPrefix = { fg = "#E0E0E0", bg = "#333333" },
 	SmartMotionSearchPrefixDim = { fg = "#AAAAAA", bg = "#1F1F1F" },
+	SmartMotionSelected = { fg = "#FAFAFA", bg = "#2FD070", bold = true },
 }
 
 local M = {}

--- a/lua/smart-motion/presets.lua
+++ b/lua/smart-motion/presets.lua
@@ -188,6 +188,13 @@ function presets.search(exclude)
 	vim.keymap.set({ "n", "v" }, ",", function()
 		char_repeat.run(true)
 	end, { desc = "Repeat last char motion (reversed)", noremap = true, silent = true })
+
+	-- Register gs keymap for visual range selection
+	if not (type(exclude) == "table" and exclude["gs"] == false) then
+		vim.keymap.set("n", "gs", function()
+			require("smart-motion.actions.visual_select").run()
+		end, { desc = "Visual select via labels", noremap = true, silent = true })
+	end
 end
 
 --- @param exclude? SmartMotionPresetKey.Delete[]
@@ -444,6 +451,19 @@ function presets.misc(exclude)
 			},
 		},
 	}, exclude)
+
+	-- Register gmd/gmy keymaps for multi-cursor edit
+	if not (type(exclude) == "table" and exclude["gmd"] == false) then
+		vim.keymap.set("n", "gmd", function()
+			require("smart-motion.actions.multi_edit").run("delete")
+		end, { desc = "Multi-cursor delete", noremap = true, silent = true })
+	end
+
+	if not (type(exclude) == "table" and exclude["gmy"] == false) then
+		vim.keymap.set("n", "gmy", function()
+			require("smart-motion.actions.multi_edit").run("yank")
+		end, { desc = "Multi-cursor yank", noremap = true, silent = true })
+	end
 end
 
 --- @param exclude? string[]
@@ -481,6 +501,22 @@ function presets.treesitter(exclude)
 		"impl_item",
 		"type_alias_declaration",
 		"module",
+	}
+
+	local scope_node_types = {
+		-- Control flow
+		"if_statement", "if_expression", "else_clause", "elif_clause",
+		"switch_statement", "switch_expression", "match_expression",
+		"case_statement", "case_clause",
+		-- Loops
+		"while_statement", "while_expression",
+		"for_statement", "for_expression", "for_in_statement", "for_of_statement",
+		"do_statement", "loop_expression", "repeat_statement",
+		-- Exception handling
+		"try_statement", "catch_clause", "except_clause", "finally_clause",
+		-- Blocks/closures
+		"block", "closure_expression", "lambda", "lambda_expression",
+		"with_statement", "do_block",
 	}
 
 	presets._register({
@@ -552,6 +588,42 @@ function presets.treesitter(exclude)
 				description = "Jump to a class/struct definition before the cursor",
 				motion_state = {
 					ts_node_types = class_node_types,
+					multi_window = true,
+				},
+			},
+		},
+		["]b"] = {
+			collector = "treesitter",
+			extractor = "pass_through",
+			modifier = "weight_distance",
+			filter = "filter_words_after_cursor",
+			visualizer = "hint_start",
+			action = "jump_centered",
+			map = true,
+			modes = { "n", "o" },
+			metadata = {
+				label = "Jump to Next Block/Scope",
+				description = "Jump to a block/scope boundary after the cursor",
+				motion_state = {
+					ts_node_types = scope_node_types,
+					multi_window = true,
+				},
+			},
+		},
+		["[b"] = {
+			collector = "treesitter",
+			extractor = "pass_through",
+			modifier = "weight_distance",
+			filter = "filter_words_before_cursor",
+			visualizer = "hint_start",
+			action = "jump_centered",
+			map = true,
+			modes = { "n", "o" },
+			metadata = {
+				label = "Jump to Previous Block/Scope",
+				description = "Jump to a block/scope boundary before the cursor",
+				motion_state = {
+					ts_node_types = scope_node_types,
 					multi_window = true,
 				},
 			},
@@ -683,6 +755,13 @@ function presets.treesitter(exclude)
 			},
 		},
 	}, exclude)
+
+	-- Register saa keymap for argument swap
+	if not (type(exclude) == "table" and exclude["saa"] == false) then
+		vim.keymap.set("n", "saa", function()
+			require("smart-motion.actions.swap").run()
+		end, { desc = "Swap two arguments", noremap = true, silent = true })
+	end
 end
 
 --- @param exclude? string[]

--- a/lua/smart-motion/types.lua
+++ b/lua/smart-motion/types.lua
@@ -34,11 +34,12 @@
 
 ---@alias SmartMotionPresetKey.Words "w" | "b" | "e" | "ge"
 ---@alias SmartMotionPresetKey.Lines "j" | "k"
----@alias SmartMotionPresetKey.Search "s" | "S" | "f" | "F" | "t" | "T"
+---@alias SmartMotionPresetKey.Search "s" | "S" | "f" | "F" | "t" | "T" | "gs"
 ---@alias SmartMotionPresetKey.Delete "d" | "dt" | "dT" | "df" | "dF" | "rdw" | "rdl"
 ---@alias SmartMotionPresetKey.Yank "y" | "yt" | "yT" | "yf" | "yF" | "ryw" | "ryl"
 ---@alias SmartMotionPresetKey.Change "c" | "ct" | "cT" | "cf" | "cF"
----@alias SmartMotionPresetKey.Treesitter "]]" | "[[" | "]c" | "[c" | "daa" | "caa" | "yaa" | "dfn" | "cfn" | "yfn"
+---@alias SmartMotionPresetKey.Treesitter "]]" | "[[" | "]c" | "[c" | "]b" | "[b" | "daa" | "caa" | "yaa" | "dfn" | "cfn" | "yfn" | "saa"
+---@alias SmartMotionPresetKey.Misc "." | "gmd" | "gmy"
 ---@alias SmartMotionPresetKey.Diagnostics "]d" | "[d" | "]e" | "[e"
 
 ---@class SmartMotionPresetsModule


### PR DESCRIPTION
Add four new features beyond flash-style navigation:

- Scope motions (]b/[b): treesitter-based jump to control flow, loops, exception handling, and block/closure nodes across languages
- Visual range selection (gs): dual label pick to enter visual mode spanning two word targets, works across windows
- Argument swap (saa): dual label pick on treesitter arguments, swaps their text with position-stable replacement
- Multi-cursor edit (gmd/gmy): toggle-based multi-selection with SmartMotionSelected highlight, delete or yank all selected words

New shared infrastructure:
- core/dual_selection.lua: two-round label selection helper
- core/multi_selection.lua: toggle-based multi-target selection

Updated all documentation (README, presets, advanced, config, defaults) to cover features from all tier sessions including t/T, ;/,, native search labels, and all tier 3 features.