### PR TITLE
feat: add git hunk motions with gitsigns integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ One plugin replaces hop, leap, flash, and mini.jump — then goes further with t
 - 🌲 **Treesitter incremental select** — `gS` selects node at cursor, `;` expands to parent, `,` shrinks to child
 - 🔎 **Treesitter search** — `R` searches text and selects the surrounding syntax node (works with operators: `dR`, `yR`, `cR`)
 - 🩺 **Diagnostics jumping** — navigate all diagnostics (`]d`/`[d`) or errors only (`]e`/`[e`)
+- 🔀 **Git hunk jumping** — navigate git changed regions (`]g`/`[g`) with gitsigns.nvim integration
 - 🔎 **2-char find** — `f`/`F` for leap-style two-character search with labels
 - 🔍 **Live search** — `s` for incremental search with labeled results across all visible text
 - 🔎 **Fuzzy search** — `S` for fuzzy matching (type "fn" to match "function", "filename", etc.)
@@ -45,7 +46,7 @@ One plugin replaces hop, leap, flash, and mini.jump — then goes further with t
 - ✏️ **Multi-cursor edit** — `gmd`/`gmy` toggle-select multiple words, then delete or yank them all at once
 - 🔁 **Repeat** — `.` repeats the last SmartMotion
 - 🧩 **Fully modular pipeline** — Collector → Extractor → Modifier → Filter → Visualizer → Selection → Action. Every stage is replaceable. Build entirely custom motions from scratch.
-- 📦 **10 presets, 50+ keybindings** — enable what you want, disable what you don't
+- 📦 **11 presets, 50+ keybindings** — enable what you want, disable what you don't
 
 ---
 
@@ -67,6 +68,7 @@ return {
       paste = true,        -- p, P
       treesitter = true,   -- ]], [[, ]c, [c, ]b, [b, daa, caa, yaa, dfn, cfn, yfn, saa
       diagnostics = true,  -- ]d, [d, ]e, [e
+      git = true,          -- ]g, [g
       misc = true,         -- . (repeat), gmd, gmy
     },
   },
@@ -218,6 +220,20 @@ Works across Lua, Python, JavaScript, TypeScript, Rust, Go, C, C++, Java, C#, an
 </details>
 
 <details>
+<summary><b>🔀 Git</b> — <code>]g</code> <code>[g</code> 🪟</summary>
+
+| Key  | Mode | Description                              |
+|------|------|------------------------------------------|
+| `]g` | n, o | Jump to next git hunk (changed region)   |
+| `[g` | n, o | Jump to previous git hunk                |
+
+> Works best with [gitsigns.nvim](https://github.com/lewis6991/gitsigns.nvim) installed. Falls back to `git diff` parsing without gitsigns.
+
+> Multi-window: labels appear in all visible splits.
+
+</details>
+
+<details>
 <summary><b>🔁 Misc</b> — <code>.</code> <code>gmd</code> <code>gmy</code></summary>
 
 | Key   | Mode | Description                                          |
@@ -258,7 +274,7 @@ gqj   — format from cursor to labeled line
 >]]   — indent from cursor to labeled function
 ```
 
-All jump-only motions (`w`, `b`, `e`, `ge`, `j`, `k`, `s`, `f`, `F`, `t`, `T`, `]]`, `[[`, `]c`, `[c`, `]b`, `[b`, `]d`, `[d`, `]e`, `[e`) are available in operator-pending mode. SmartMotion's own operators (`d`, `y`, `c`, `p`, `P`) and standalone actions (`gs`, `saa`, `gmd`, `gmy`) are not — they handle operations internally.
+All jump-only motions (`w`, `b`, `e`, `ge`, `j`, `k`, `s`, `f`, `F`, `t`, `T`, `]]`, `[[`, `]c`, `[c`, `]b`, `[b`, `]d`, `[d`, `]e`, `[e`, `]g`, `[g`) are available in operator-pending mode. SmartMotion's own operators (`d`, `y`, `c`, `p`, `P`) and standalone actions (`gs`, `saa`, `gmd`, `gmy`) are not — they handle operations internally.
 
 ---
 
@@ -270,6 +286,7 @@ Enabled by default for:
 - **Search**: `s`, `f`, `F`, `t`, `T`, `;`, `,`, `gs`
 - **Treesitter navigation**: `]]`, `[[`, `]c`, `[c`, `]b`, `[b`
 - **Diagnostics**: `]d`, `[d`, `]e`, `[e`
+- **Git**: `]g`, `[g`
 
 Word and line motions (`w`, `b`, `e`, `ge`, `j`, `k`) stay single-window — directional motions within one window are the natural UX.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -64,6 +64,7 @@ return {
       paste = true,
       treesitter = true,
       diagnostics = true,
+      git = true,
       misc = true,
     },
   },

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -146,6 +146,21 @@ This reference documents all the motions included in the default SmartMotion pre
 
 ---
 
+## Preset: `git`
+
+| Key  | Mode | Multi-window | Description                                     |
+| ---- | ---- | ------------ | ----------------------------------------------- |
+| `]g` | n, o | yes          | Jump to next git hunk (changed region) after cursor  |
+| `[g` | n, o | yes          | Jump to previous git hunk before cursor              |
+
+> [!NOTE]
+> Git hunk motions work best with [gitsigns.nvim](https://github.com/lewis6991/gitsigns.nvim) installed. SmartMotion uses gitsigns' API for accurate hunk detection. Without gitsigns, it falls back to parsing `git diff` output directly.
+
+> [!NOTE]
+> A "hunk" is a contiguous region of changed lines in git. This includes added lines, deleted lines, and modified lines. The metadata includes `hunk_type` ("add", "delete", or "change") for potential custom actions.
+
+---
+
 ## Preset: `misc`
 
 | Key   | Description                                                        |

--- a/lua/smart-motion/collectors/git_hunks.lua
+++ b/lua/smart-motion/collectors/git_hunks.lua
@@ -1,0 +1,151 @@
+local log = require("smart-motion.core.log")
+
+---@type SmartMotionCollectorModuleEntry
+local M = {}
+
+--- Try to get hunks from gitsigns.nvim (most common git integration)
+--- @param bufnr number
+--- @return table[]|nil hunks List of hunks or nil if gitsigns not available
+local function get_gitsigns_hunks(bufnr)
+	local ok, gitsigns = pcall(require, "gitsigns")
+	if not ok then
+		return nil
+	end
+
+	-- gitsigns.get_hunks() returns hunks for current buffer
+	-- Each hunk has: added, removed, head, lines, start, vend
+	local hunks = gitsigns.get_hunks(bufnr)
+	if not hunks or #hunks == 0 then
+		return nil
+	end
+
+	return hunks
+end
+
+--- Fallback: get hunks by parsing git diff output
+--- @param bufnr number
+--- @return table[]|nil hunks List of hunks or nil if not a git repo
+local function get_git_diff_hunks(bufnr)
+	local filepath = vim.api.nvim_buf_get_name(bufnr)
+	if filepath == "" then
+		return nil
+	end
+
+	-- Get the directory of the file for git command
+	local dir = vim.fn.fnamemodify(filepath, ":h")
+
+	-- Run git diff to get changed lines
+	-- Using -U0 for minimal context, parsing @@ hunk headers
+	local cmd = string.format(
+		"cd %s && git diff --no-color -U0 -- %s 2>/dev/null",
+		vim.fn.shellescape(dir),
+		vim.fn.shellescape(vim.fn.fnamemodify(filepath, ":t"))
+	)
+
+	local output = vim.fn.system(cmd)
+	if vim.v.shell_error ~= 0 or output == "" then
+		-- Try git diff HEAD for staged changes
+		cmd = string.format(
+			"cd %s && git diff HEAD --no-color -U0 -- %s 2>/dev/null",
+			vim.fn.shellescape(dir),
+			vim.fn.shellescape(vim.fn.fnamemodify(filepath, ":t"))
+		)
+		output = vim.fn.system(cmd)
+		if vim.v.shell_error ~= 0 or output == "" then
+			return nil
+		end
+	end
+
+	local hunks = {}
+	-- Parse @@ -old_start,old_count +new_start,new_count @@ headers
+	for line in output:gmatch("[^\n]+") do
+		local new_start, new_count = line:match("^@@ %-%d+,?%d* %+(%d+),?(%d*) @@")
+		if new_start then
+			new_start = tonumber(new_start)
+			new_count = tonumber(new_count) or 1
+			if new_count == 0 then
+				new_count = 1 -- Deletion shows as 0 lines, treat as 1 for jumping
+			end
+			table.insert(hunks, {
+				start = new_start,
+				vend = new_start + new_count - 1,
+				type = "change",
+			})
+		end
+	end
+
+	return #hunks > 0 and hunks or nil
+end
+
+--- Determine hunk type from gitsigns hunk data
+--- @param hunk table
+--- @return string "add"|"delete"|"change"
+local function get_hunk_type(hunk)
+	if hunk.type then
+		return hunk.type
+	end
+	-- Gitsigns format
+	if hunk.added and hunk.removed then
+		if hunk.added.count > 0 and hunk.removed.count > 0 then
+			return "change"
+		elseif hunk.added.count > 0 then
+			return "add"
+		else
+			return "delete"
+		end
+	end
+	return "change"
+end
+
+--- Collects git hunks (changed regions) as targets.
+--- Supports gitsigns.nvim if available, falls back to git diff parsing.
+--- @return thread A coroutine generator yielding target-like objects
+function M.run()
+	return coroutine.create(function(ctx, cfg, motion_state)
+		local bufnr = ctx.bufnr
+
+		-- Try gitsigns first (most common and accurate)
+		local hunks = get_gitsigns_hunks(bufnr)
+
+		-- Fallback to git diff parsing
+		if not hunks then
+			hunks = get_git_diff_hunks(bufnr)
+		end
+
+		if not hunks or #hunks == 0 then
+			log.debug("Git hunks collector: no hunks in buffer " .. tostring(bufnr))
+			return
+		end
+
+		for _, hunk in ipairs(hunks) do
+			local start_line = hunk.start or (hunk.added and hunk.added.start) or 1
+			local end_line = hunk.vend or hunk["end"] or start_line
+
+			-- Get first non-blank column on the start line for better positioning
+			local line_text = vim.api.nvim_buf_get_lines(bufnr, start_line - 1, start_line, false)[1] or ""
+			local first_col = line_text:find("%S") or 1
+			first_col = first_col - 1 -- Convert to 0-indexed
+
+			local hunk_type = get_hunk_type(hunk)
+
+			coroutine.yield({
+				text = line_text,
+				start_pos = { row = start_line - 1, col = first_col }, -- 0-indexed
+				end_pos = { row = end_line - 1, col = #line_text },
+				type = "git_hunk",
+				metadata = {
+					hunk_type = hunk_type,
+					start_line = start_line,
+					end_line = end_line,
+				},
+			})
+		end
+	end)
+end
+
+M.metadata = {
+	label = "Git Hunks Collector",
+	description = "Collects git changed regions (hunks) as jump targets. Supports gitsigns.nvim or falls back to git diff.",
+}
+
+return M

--- a/lua/smart-motion/collectors/init.lua
+++ b/lua/smart-motion/collectors/init.lua
@@ -2,6 +2,7 @@ local lines = require("smart-motion.collectors.lines")
 local history = require("smart-motion.collectors.history")
 local treesitter = require("smart-motion.collectors.treesitter")
 local diagnostics = require("smart-motion.collectors.diagnostics")
+local git_hunks = require("smart-motion.collectors.git_hunks")
 
 ---@type SmartMotionRegistry<SmartMotionCollectorModuleEntry>
 local collectors = require("smart-motion.core.registry")("collectors")
@@ -12,6 +13,7 @@ collectors.register_many({
 	history = history,
 	treesitter = treesitter,
 	diagnostics = diagnostics,
+	git_hunks = git_hunks,
 })
 
 return collectors

--- a/lua/smart-motion/presets.lua
+++ b/lua/smart-motion/presets.lua
@@ -870,6 +870,46 @@ function presets.diagnostics(exclude)
 	}, exclude)
 end
 
+--- @param exclude? SmartMotionPresetKey.Git[]
+function presets.git(exclude)
+	presets._register({
+		["]g"] = {
+			collector = "git_hunks",
+			extractor = "pass_through",
+			modifier = "weight_distance",
+			filter = "filter_words_after_cursor",
+			visualizer = "hint_start",
+			action = "jump_centered",
+			map = true,
+			modes = { "n", "o" },
+			metadata = {
+				label = "Jump to Next Git Hunk",
+				description = "Jump to a git changed region after the cursor",
+				motion_state = {
+					multi_window = true,
+				},
+			},
+		},
+		["[g"] = {
+			collector = "git_hunks",
+			extractor = "pass_through",
+			modifier = "weight_distance",
+			filter = "filter_words_before_cursor",
+			visualizer = "hint_start",
+			action = "jump_centered",
+			map = true,
+			modes = { "n", "o" },
+			metadata = {
+				label = "Jump to Previous Git Hunk",
+				description = "Jump to a git changed region before the cursor",
+				motion_state = {
+					multi_window = true,
+				},
+			},
+		},
+	}, exclude)
+end
+
 --- Internal registration logic with optional filtering.
 --- @param motions_list table<string, SmartMotionModule>
 --- @param exclude? string[]

--- a/lua/smart-motion/types.lua
+++ b/lua/smart-motion/types.lua
@@ -30,6 +30,7 @@
 ---@field change? true | SmartMotionPresetKey.Change[]
 ---@field treesitter? true | SmartMotionPresetKey.Treesitter[]
 ---@field diagnostics? true | SmartMotionPresetKey.Diagnostics[]
+---@field git? true | SmartMotionPresetKey.Git[]
 ---@field [string] boolean | string[]
 
 ---@alias SmartMotionPresetKey.Words "w" | "b" | "e" | "ge"
@@ -41,6 +42,7 @@
 ---@alias SmartMotionPresetKey.Treesitter "]]" | "[[" | "]c" | "[c" | "]b" | "[b" | "daa" | "caa" | "yaa" | "dfn" | "cfn" | "yfn" | "saa" | "gS" | "R"
 ---@alias SmartMotionPresetKey.Misc "." | "gmd" | "gmy"
 ---@alias SmartMotionPresetKey.Diagnostics "]d" | "[d" | "]e" | "[e"
+---@alias SmartMotionPresetKey.Git "]g" | "[g"
 
 ---@class SmartMotionPresetsModule
 ---@field words fun(exclude?: SmartMotionPresetKey.Words[])
@@ -49,6 +51,10 @@
 ---@field delete fun(exclude?: SmartMotionPresetKey.Delete[])
 ---@field yank fun(exclude?: SmartMotionPresetKey.Yank[])
 ---@field change fun(exclude?: SmartMotionPresetKey.Change[])
+---@field treesitter fun(exclude?: SmartMotionPresetKey.Treesitter[])
+---@field diagnostics fun(exclude?: SmartMotionPresetKey.Diagnostics[])
+---@field git fun(exclude?: SmartMotionPresetKey.Git[])
+---@field misc fun(exclude?: SmartMotionPresetKey.Misc[])
 ---@field _register fun(motions_list: table<string, SmartMotionModule>, exclude?: string[])
 
 ---@class SmartMotionContext

--- a/tests/git.lua
+++ b/tests/git.lua
@@ -1,0 +1,78 @@
+-- SmartMotion Playground: Git Motions
+-- Presets: ]g, [g
+--
+-- INSTRUCTIONS:
+--   ]g → jump to next git hunk (changed region) after cursor
+--   [g → jump to previous git hunk before cursor
+--
+-- SETUP:
+--   This file needs to be in a git repository with uncommitted changes
+--   to see hunks. Make some edits and don't commit them.
+--
+-- MULTI-WINDOW:
+--   :vsplit another_file.lua
+--   Press ]g — labels should appear on hunks in BOTH windows
+--
+-- GITSIGNS INTEGRATION:
+--   If you have gitsigns.nvim installed, SmartMotion uses its API
+--   for accurate hunk detection. Otherwise falls back to git diff.
+
+-- ── Section 1: Make changes here to create hunks ─────────────────
+
+local function example_function()
+	-- Edit this line or add new lines to create a git hunk
+	-- Then press ]g or [g to jump between hunks
+	return "original content"
+end
+
+local config = {
+	enabled = true,
+	timeout = 5000,
+	-- Add or remove fields to create hunks
+}
+
+-- ── Section 2: Another section for more hunks ────────────────────
+
+local function another_function(param)
+	-- Modify this function to create another hunk
+	local result = param * 2
+	return result
+end
+
+-- Add new functions here to create insertion hunks
+
+-- ── Section 3: Testing workflow ──────────────────────────────────
+
+-- WORKFLOW TEST:
+-- 1. Make a change somewhere in this file (add a line, modify text)
+-- 2. Press ]g from the top — labels appear on all hunks below cursor
+-- 3. Press a label key to jump to that hunk
+-- 4. Press [g to go back to previous hunks
+--
+-- TIP: Works great with gitsigns.nvim preview_hunk and reset_hunk
+
+local function test_workflow()
+	-- Change this
+	local x = 1
+	local y = 2
+	return x + y
+end
+
+-- ── Section 4: Hunk types ────────────────────────────────────────
+
+-- Git tracks three types of changes:
+-- 1. Added lines (new content)
+-- 2. Removed lines (deleted content, shown at deletion point)
+-- 3. Changed lines (modified content)
+--
+-- SmartMotion shows labels on all hunk types.
+-- The metadata includes hunk_type: "add", "delete", or "change"
+
+-- Try:
+-- 1. Add a new function below this comment → creates "add" hunk
+-- 2. Delete the comment above → creates "delete" hunk
+-- 3. Modify existing code → creates "change" hunk
+
+local function final_example()
+	return "test"
+end


### PR DESCRIPTION
- Add git_hunks collector that integrates with gitsigns.nvim or falls back to git diff parsing
- Add ]g/[g presets for jumping to next/previous git changed region
- Support multi-window jumping and operator-pending mode
- Include hunk_type metadata (add, delete, change) for potential custom actions