### PR TITLE
feat: improve R (treesitter search) with two-phase selection and oper…

### DIFF
--- a/lua/smart-motion/actions/treesitter_search.lua
+++ b/lua/smart-motion/actions/treesitter_search.lua
@@ -65,13 +65,27 @@ local function find_matches(pattern, bufnr, top_line, bottom_line)
 	return matches
 end
 
+--- Root-level node types to exclude (too broad — covers the whole file).
+local ROOT_NODE_TYPES = {
+	source_file = true,
+	program = true,
+	module = true,
+	chunk = true,
+	translation_unit = true,
+	source = true,
+	stylesheet = true,
+	document = true,
+}
+
 --- Converts text matches to treesitter node targets (deduped by range).
+--- Returns the smallest named node at each match position.
 ---@param matches table[]
 ---@param bufnr integer
 ---@return table[] targets
 local function matches_to_node_targets(matches, bufnr)
 	local targets = {}
 	local seen_ranges = {}
+	local winid = vim.api.nvim_get_current_win()
 
 	for _, match in ipairs(matches) do
 		local node = get_node_at_pos(bufnr, match.row, match.col)
@@ -88,13 +102,67 @@ local function matches_to_node_targets(matches, bufnr)
 					type = "treesitter",
 					metadata = {
 						bufnr = bufnr,
-						winid = vim.api.nvim_get_current_win(),
+						winid = winid,
 						node_type = node:type(),
 						match_row = match.row,
 						match_col = match.col,
 					},
 				})
 			end
+		end
+	end
+
+	return targets
+end
+
+--- From a selected target position, walks up the treesitter tree and
+--- collects all named ancestor nodes as targets (deduped, excluding root).
+---@param bufnr integer
+---@param row integer 0-indexed
+---@param col integer 0-indexed
+---@return table[] targets
+local function collect_ancestor_targets(bufnr, row, col)
+	local targets = {}
+	local seen_ranges = {}
+	local winid = vim.api.nvim_get_current_win()
+
+	local node = get_node_at_pos(bufnr, row, col)
+	if not node then
+		return targets
+	end
+
+	-- Start from the parent of the smallest node (the smallest node was already selected)
+	node = node:parent()
+	while node and not node:named() do
+		node = node:parent()
+	end
+
+	while node do
+		if ROOT_NODE_TYPES[node:type()] then
+			break
+		end
+
+		local sr, sc, er, ec = node:range()
+		local range_key = string.format("%d:%d-%d:%d", sr, sc, er, ec)
+
+		if not seen_ranges[range_key] then
+			seen_ranges[range_key] = true
+			table.insert(targets, {
+				text = vim.treesitter.get_node_text(node, bufnr),
+				start_pos = { row = sr, col = sc },
+				end_pos = { row = er, col = ec },
+				type = "treesitter",
+				metadata = {
+					bufnr = bufnr,
+					winid = winid,
+					node_type = node:type(),
+				},
+			})
+		end
+
+		node = node:parent()
+		while node and not node:named() do
+			node = node:parent()
 		end
 	end
 
@@ -110,7 +178,13 @@ function M.run(mode, operator)
 	local highlight = require("smart-motion.core.highlight")
 	local hints = require("smart-motion.visualizers.hints")
 	local selection = require("smart-motion.core.selection")
+	local flow_state = require("smart-motion.core.flow_state")
 	local cfg_mod = require("smart-motion.config")
+
+	-- Reset flow state so it doesn't interfere with our two-phase selection.
+	-- The y/d/c handler's evaluate_flow_at_motion_start refreshes the timestamp,
+	-- which would cause evaluate_flow_at_selection to skip phase 2.
+	flow_state.reset()
 
 	local cfg = cfg_mod.validated
 	if not cfg then
@@ -241,22 +315,55 @@ function M.run(mode, operator)
 		return
 	end
 
-	-- Transition from search to selection: brighten hints (matches pipeline exit.lua behavior)
+	-- Phase 1: Select a match target
 	motion_state.is_searching_mode = false
 	highlight.clear(ctx, cfg, motion_state)
 	hints.run(ctx, cfg, motion_state)
 	vim.cmd("redraw")
 
-	-- Wait for label selection
 	selection.wait_for_hint_selection(ctx, cfg, motion_state)
 
-	-- Clean up highlights
 	highlight.clear(ctx, cfg, motion_state)
 	vim.cmd("redraw")
 
-	local target = motion_state.selected_jump_target
-	if not target then
+	local match_target = motion_state.selected_jump_target
+	if not match_target then
 		return
+	end
+
+	-- Phase 2: Walk up from the selected node and label all ancestor nodes
+	local ancestors = collect_ancestor_targets(bufnr, match_target.start_pos.row, match_target.start_pos.col)
+
+	-- Reset flow state again — phase 1's evaluate_flow_at_selection refreshed
+	-- the timestamp, which would cause phase 2's selection to be skipped
+	flow_state.reset()
+
+	local target
+	if #ancestors == 0 then
+		-- No ancestors above — use the match target itself
+		target = match_target
+	else
+		-- Reset selection state for second round
+		motion_state.jump_targets = ancestors
+		motion_state.jump_target_count = #ancestors
+		motion_state.assigned_hint_labels = {}
+		motion_state.selection_mode = consts.SELECTION_MODE.FIRST
+		motion_state.selection_first_char = nil
+		motion_state.selected_jump_target = nil
+
+		state.finalize_motion_state(ctx, cfg, motion_state)
+		hints.run(ctx, cfg, motion_state)
+		vim.cmd("redraw")
+
+		selection.wait_for_hint_selection(ctx, cfg, motion_state)
+
+		highlight.clear(ctx, cfg, motion_state)
+		vim.cmd("redraw")
+
+		target = motion_state.selected_jump_target
+		if not target then
+			return
+		end
 	end
 
 	-- Record to history so g. can navigate back here
@@ -274,29 +381,40 @@ function M.run(mode, operator)
 	local er = target.end_pos.row
 	local ec = target.end_pos.col
 
-	if is_operator_pending and pending_operator then
-		-- Defer the operation to run after the op-pending callback returns.
-		-- The callback returns with zero cursor movement, which cancels the native
-		-- operator. Then we perform the operation cleanly via API.
-		local op = pending_operator
-		vim.schedule(function()
-			local node_lines = vim.api.nvim_buf_get_text(bufnr, sr, sc, er, ec, {})
-			local text = table.concat(node_lines, "\n")
+	-- Move cursor to target start for all operations
+	vim.api.nvim_win_set_cursor(winid, { sr + 1, sc })
 
-			if op == "y" then
-				vim.fn.setreg('"', text, "v")
-				vim.api.nvim_win_set_cursor(winid, { sr + 1, sc })
-			elseif op == "d" then
-				vim.fn.setreg('"', text, "v")
-				vim.api.nvim_buf_set_text(bufnr, sr, sc, er, ec, { "" })
-				vim.api.nvim_win_set_cursor(winid, { sr + 1, math.max(sc, 0) })
-			elseif op == "c" then
-				vim.fn.setreg('"', text, "v")
-				vim.api.nvim_buf_set_text(bufnr, sr, sc, er, ec, { "" })
-				vim.api.nvim_win_set_cursor(winid, { sr + 1, sc })
-				vim.cmd("startinsert")
+	if pending_operator then
+		-- Called directly from infer.run (not operator-pending mode), so we
+		-- can apply operations synchronously without native operator conflicts.
+		local node_lines = vim.api.nvim_buf_get_text(bufnr, sr, sc, er, ec, {})
+		local text = table.concat(node_lines, "\n")
+		-- Set unnamed register, yank register, and clipboard registers
+		vim.fn.setreg('"', text, "c")
+		vim.fn.setreg('0', text, "c")
+		vim.fn.setreg('+', text, "c")
+		vim.fn.setreg('*', text, "c")
+
+		if pending_operator == "y" then
+			-- Highlight the yanked range manually (on_yank only highlights around cursor)
+			local ns = vim.api.nvim_create_namespace("smart_motion_yank")
+			for row = sr, er do
+				local line = vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1] or ""
+				local col_start = (row == sr) and sc or 0
+				local col_end = (row == er) and ec or #line
+				if col_end > col_start then
+					vim.api.nvim_buf_add_highlight(bufnr, ns, "IncSearch", row, col_start, col_end)
+				end
 			end
-		end)
+			vim.defer_fn(function()
+				vim.api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
+			end, 150)
+		elseif pending_operator == "d" then
+			vim.api.nvim_buf_set_text(bufnr, sr, sc, er, ec, { "" })
+		elseif pending_operator == "c" then
+			vim.api.nvim_buf_set_text(bufnr, sr, sc, er, ec, { "" })
+			vim.cmd("startinsert")
+		end
 	elseif is_visual then
 		-- In visual mode, adjust selection to the node
 		vim.api.nvim_win_set_cursor(winid, { sr + 1, sc })

--- a/lua/smart-motion/core/engine/infer.lua
+++ b/lua/smart-motion/core/engine/infer.lua
@@ -53,6 +53,14 @@ function M.run(ctx, cfg, motion_state)
 			end
 		end
 
+		-- Special case: R (treesitter search) called from operator context (yR, dR, cR).
+		-- Call treesitter_search directly with the operator instead of feeding keys
+		-- through operator-pending mode, which has timing issues with vim.schedule.
+		if motion_key == "R" then
+			require("smart-motion.actions.treesitter_search").run(nil, motion_state.motion.trigger_key)
+			exit.throw(EXIT_TYPE.EARLY_EXIT)
+		end
+
 		-- Feed trigger key with noremap to get native operator behavior (avoids recursion),
 		-- but feed the motion key with remap so user/plugin "o" mode keymaps fire (e.g. R).
 		vim.api.nvim_feedkeys(motion_state.motion.trigger_key, "n", false)


### PR DESCRIPTION
…ator support

- Two-phase selection: pick match location, then pick ancestor scope
- Collect all named ancestor nodes up to root (excluding source_file, program, etc.)
- yR/dR/cR now work correctly by calling treesitter_search directly from infer.run
- Support clipboard=unnamedplus by setting all registers (", 0, +, *)
- Manual yank highlight for the full multiline range
- Cursor moves to target start for visual feedback
- Reset flow_state between phases to prevent selection skipping