### PR TITLE
docs: update R (treesitter search) documentation for two-phase selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ One plugin replaces hop, leap, flash, and mini.jump — then goes further with t
 - 📡 **Remote operations** — `rdw`, `rdl`, `ryw`, `ryl` delete or yank words and lines without moving the cursor
 - 🌳 **Treesitter-aware motions** — jump to functions (`]]`/`[[`), classes (`]c`/`[c`), scopes/blocks (`]b`/`[b`), delete/change/yank function names (`dfn`, `cfn`, `yfn`), and arguments (`daa`, `caa`, `yaa`)
 - 🌲 **Treesitter incremental select** — `gS` selects node at cursor, `;` expands to parent, `,` shrinks to child
-- 🔎 **Treesitter search** — `R` searches text and selects the surrounding syntax node (works with operators: `dR`, `yR`, `cR`)
+- 🔎 **Treesitter search** — `R` searches text, then lets you pick which surrounding syntax node to select (works with operators: `dR`, `yR`, `cR`)
 - 🩺 **Diagnostics jumping** — navigate all diagnostics (`]d`/`[d`) or errors only (`]e`/`[e`)
 - 🔀 **Git hunk jumping** — navigate git changed regions (`]g`/`[g`) with gitsigns.nvim integration
 - 📋 **Quickfix/location list** — navigate quickfix (`]q`/`[q`) and location list (`]l`/`[l`) entries with labels
@@ -202,7 +202,7 @@ Every preset and its keybindings at a glance. Enable a preset and all its bindin
 | `yfn` | n       | Yank function name                                    |
 | `saa` | n       | Swap two arguments — pick two, swap their positions   |
 | `gS`  | n, x    | Treesitter incremental select — `;` expand, `,` shrink |
-| `R`   | n, x, o | Treesitter search — search text, select surrounding node |
+| `R`   | n, x, o | Treesitter search — search text, pick match, pick ancestor scope |
 
 Works across Lua, Python, JavaScript, TypeScript, Rust, Go, C, C++, Java, C#, and Ruby. Non-matching node types are safely ignored.
 

--- a/docs/Advanced-Features.md
+++ b/docs/Advanced-Features.md
@@ -367,25 +367,44 @@ Quickly select increasingly larger code structures without counting or guessing 
 
 ## Treesitter Search
 
-`R` searches for text and selects the surrounding syntax node.
+`R` searches for text and lets you select the surrounding syntax node at any level of the tree.
+
+### Two-Phase Selection
+
+Unlike Flash's single-step approach (which labels all ancestor nodes of all matches at once), SmartMotion uses a deliberate two-phase flow:
+
+**Phase 1 — Pick the match:**
+1. Press `R` (or `dR`, `yR`, `cR`)
+2. Type search text
+3. Labels appear on the smallest named node at each match
+4. Select a label to choose which match you care about
+
+**Phase 2 — Pick the scope:**
+1. Labels appear on all ancestor nodes (identifier → statement → block → function → class, etc.)
+2. Select which level of the tree to operate on
+3. If there are no ancestors above (already at root), the match target is used directly
+
+### Why Two Phases?
+
+With many matches, Flash's single-step can flood the screen with labels — every match generates labels for itself AND all its ancestors simultaneously. SmartMotion's approach narrows down first (which match?), then shows a clean set of ancestors (how much to select?).
+
+The end result is identical: the operator applies to the full treesitter node range you select. The path to get there is just more deliberate.
 
 ### In Normal/Visual Mode
 
-1. Press `R`
-2. Type search text
-3. Labels appear on nodes containing matches (deduplicated by range)
-4. Select a label
-5. Node enters visual selection
+```
+Press R → type "config" → labels on matches → pick one → labels on ancestors → pick scope → visual selection
+```
 
-### In Operator-Pending Mode
-
-Works with any operator:
+### With Operators (`dR`, `yR`, `cR`)
 
 ```
-dR → type "error" → select → entire node containing "error" is deleted
-yR → type "func" → select → entire node containing "func" is yanked
-cR → type "name" → select → node changed, insert mode
+dR → type "error" → pick match → pick ancestor → entire node deleted
+yR → type "func" → pick match → pick ancestor → entire node yanked (with highlight flash)
+cR → type "name" → pick match → pick ancestor → node deleted, insert mode
 ```
+
+Cursor moves to the target start, and for yank operations, the full multiline range flashes to confirm what was copied.
 
 ---
 

--- a/docs/Presets.md
+++ b/docs/Presets.md
@@ -285,14 +285,18 @@ Press cfn → labels appear on function names → select one → name deleted, i
 | Key | Modes | What it does |
 |-----|-------|--------------|
 | `gS` | n, x | **Incremental select** — `;` expands to parent, `,` shrinks to child |
-| `R` | n, x, o | **Treesitter search** — search text, select surrounding node |
+| `R` | n, x, o | **Treesitter search** — search text, pick match, pick ancestor scope |
 
 ```
 Press gS → smallest node at cursor selected → press ; → expands to parent node → etc.
 Shows node type in echo area. Enter confirms, ESC cancels.
 
-Press dR → type "error" → labels appear on nodes containing "error" → select → node deleted
+Press R → type "error" → labels on matches → pick match → labels on ancestors → pick scope
+Press dR → type "error" → pick match → pick ancestor → entire node deleted
+Press yR → type "func" → pick match → pick ancestor → entire node yanked (with highlight flash)
 ```
+
+**Two-phase selection:** SmartMotion's approach differs from Flash. Instead of labeling all ancestor nodes of all matches at once (which can flood the screen), you first pick which match location you care about, then pick how much of the syntax tree to select. See **[Advanced Features: Treesitter Search](Advanced-Features.md#treesitter-search)** for details.
 
 ---
 

--- a/docs/Why-SmartMotion.md
+++ b/docs/Why-SmartMotion.md
@@ -104,6 +104,8 @@ Each stage is a module. Swap any module, combine modules, or write your own. The
 | Custom motion creation | Limited | Full pipeline |
 | Plugin interop | Limited | Registry system |
 
+**Treesitter Search (`R`) Difference**: Flash labels all ancestor nodes of all matches at once in a single step. SmartMotion uses a two-phase approach: first pick which match you care about, then pick the ancestor scope. This is more deliberate — with many matches, Flash can flood the screen with labels, while SmartMotion narrows down first. The end result is identical (the operator applies to the full node), but the UX is cleaner.
+
 **When to choose Flash**: It's excellent and you're already happy with it.
 
 **When to choose SmartMotion**: You want fuzzy search, multi-cursor operations, full composability, or the ability to build entirely custom motions.


### PR DESCRIPTION
- Explain the two-phase flow: pick match, then pick ancestor scope
- Note the difference from Flash's single-step approach
- Add examples for dR, yR, cR with the new flow
- Document yank highlight flash and cursor movement