### PR TITLE
fix: cf/cF operator range and make t/T 2-char searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,17 @@ One plugin replaces hop, leap, flash, and mini.jump - then goes further with tre
 - ⚡ **Word, line, and search jumping** with home-row hint labels - forward, backward, start, end
 - 🌳 **Treesitter-aware motions** - jump to functions (`]]`/`[[`), classes (`]c`/`[c`), scopes/blocks (`]b`/`[b`), text objects for functions (`af`/`if`), classes (`ac`/`ic`), arguments (`aa`/`ia`), and function names (`fn`)
 - 📡 **Remote operations** - `rdw`, `rdl`, `ryw`, `ryl` delete or yank words and lines without moving the cursor
-- ✂️ **Until motions** - `dt`, `yt`, `ct` operate from cursor to a labeled character
+- ✂️ **Find & Till operators** - `df`/`yf`/`cf` operate from cursor to target (inclusive), `dt`/`yt`/`ct` operate from cursor to just before target (exclusive)
 - 🌲 **Treesitter incremental select** - `gS` selects node at cursor, `;` expands to parent, `,` shrinks to child
 - 🔎 **Treesitter search** - `R` searches text, then lets you pick which surrounding syntax node to select (works with operators: `dR`, `yR`, `cR`)
 - 🩺 **Diagnostics jumping** - navigate all diagnostics (`]d`/`[d`) or errors only (`]e`/`[e`)
 - 🔀 **Git hunk jumping** - navigate git changed regions (`]g`/`[g`) with gitsigns.nvim integration
 - 📋 **Quickfix/location list** - navigate quickfix (`]q`/`[q`) and location list (`]l`/`[l`) entries with labels
 - 🔖 **Marks integration** - jump to any mark with labels (`g'`), set marks remotely (`gm`)
-- 🔎 **2-char find** - `f`/`F` for leap-style two-character search with labels
+- 🔎 **2-char find** - `f`/`F` for leap-style two-character search with labels (inclusive)
+- 🎯 **2-char till** - `t`/`T` for two-character till (jump to just before/after the match, exclusive), with `;`/`,` to repeat
 - 🔍 **Live search** - `s` for incremental search with labeled results across all visible text
 - 🔎 **Fuzzy search** - `S` for fuzzy matching (type "fn" to match "function", "filename", etc.)
-- 🎯 **Till motions** - `t`/`T` for single-character till (jump to just before/after the match), with `;`/`,` to repeat
 - 🔎 **Native search labels** - `/` shows labels incrementally as you type, `<C-s>` toggles labels on/off
 - 🧠 **Label conflict avoidance** - labels can't be valid search continuations (no ambiguity)
 - 🪟 **Multi-window jumping** - search, treesitter, and diagnostic motions show labels across all visible splits. Select a label in another window and jump there instantly.
@@ -157,7 +157,7 @@ When you press `d`, `y`, `c`, or `p`, SmartMotion reads the next key and **autom
 dw    d (delete)  +  w (words extractor, after cursor filter)
 db    d (delete)  +  b (words extractor, before cursor filter)
 ds    d (delete)  +  s (live search extractor, multi-window)
-yf    y (yank)    +  f (2-char search extractor)
+yf    y (yank)    +  f (2-char search, inclusive)
 cj    c (change)  +  j (lines extractor, after cursor filter)
 ```
 
@@ -243,10 +243,10 @@ Every preset and its keybindings at a glance. Enable a preset and all its bindin
 |------|------|------------------------------------------------------|
 | `s`  | n, o | Live search across all visible text with labels      |
 | `S`  | n, o | Fuzzy search - type partial patterns to match words  |
-| `f`  | n, o | 2-char find forward with labels                      |
-| `F`  | n, o | 2-char find backward with labels                     |
-| `t`  | n, o | Till character forward (jump to just before match)   |
-| `T`  | n, o | Till character backward (jump to just after match)   |
+| `f`  | n, o | 2-char find forward (inclusive) - line-constrained   |
+| `F`  | n, o | 2-char find backward (inclusive) - line-constrained  |
+| `t`  | n, o | 2-char till forward (exclusive, just before match) - line-constrained |
+| `T`  | n, o | 2-char till backward (exclusive, just after match) - line-constrained |
 | `;`  | n, v | Repeat last f/F/t/T motion (same direction)          |
 | `,`  | n, v | Repeat last f/F/t/T motion (reversed direction)      |
 | `gs` | n    | Visual select via labels - pick two targets, enter visual mode |
@@ -266,8 +266,8 @@ Press an operator, then any motion key - SmartMotion infers the pipeline, shows 
 | `db`  | Jump to word before cursor, delete it |
 | `dj`  | Jump to line below, delete it |
 | `ds`  | Live search → pick label → delete |
-| `df`  | 2-char find → pick label → delete |
-| `dt`  | Delete till character (from cursor to target) |
+| `df`  | 2-char find → delete from cursor to target (inclusive) |
+| `dt`  | 2-char till → delete from cursor to just before target (exclusive) |
 | `dd`  | Delete current line |
 
 All work identically with `y` (yank), `c` (change), and `p`/`P` (paste).
@@ -427,9 +427,9 @@ gPA        set global pin A directly
 
 Search, treesitter, diagnostic, git, quickfix, and mark motions show labels across **all visible splits**. Select a label in another window and jump there.
 
-Enabled by default for: `s`, `f`, `F`, `t`, `T`, `]]`, `[[`, `]c`, `[c`, `]b`, `[b`, `]d`, `[d`, `]e`, `[e`, `]g`, `[g`, `]q`, `[q`, `]l`, `[l`, `g'`, `gm`
+Enabled by default for: `s`, `S`, `]]`, `[[`, `]c`, `[c`, `]b`, `[b`, `]d`, `[d`, `]e`, `[e`, `]g`, `[g`, `]q`, `[q`, `]l`, `[l`, `g'`, `gm`
 
-Word/line motions (`w`, `b`, `e`, `ge`, `j`, `k`) stay single-window - directional motions within one window are the natural UX.
+Word/line/find/till motions (`w`, `b`, `e`, `ge`, `j`, `k`, `f`, `F`, `t`, `T`) stay single-window and line-constrained by default. See [Customization](#customizing-motions) for how to make them multi-line or multi-window.
 
 ---
 
@@ -616,6 +616,45 @@ For more, see the [Wiki](https://github.com/FluxxField/smart-motion.nvim/wiki/Bu
 ```
 
 See [Wiki Configuration](https://github.com/FluxxField/smart-motion.nvim/wiki/Configuration) for details.
+
+</details>
+
+<details>
+<summary><h3>Customizing Motions</h3></summary>
+
+Individual motions within a preset can be tweaked by passing a table instead of `true`. For example, `f`/`F` and `t`/`T` are line-constrained by default. To make them work across multiple lines:
+
+```lua
+presets = {
+  search = {
+    -- Make f/F search across all lines (not just current line)
+    f = { filter = "filter_words_after_cursor" },
+    F = { filter = "filter_words_before_cursor" },
+    -- Make t/T search across all lines too
+    t = { filter = "filter_words_after_cursor" },
+    T = { filter = "filter_words_before_cursor" },
+  },
+}
+```
+
+To also enable multi-window jumping for find/till:
+
+```lua
+presets = {
+  search = {
+    f = {
+      filter = "filter_words_after_cursor",
+      metadata = { motion_state = { multi_window = true } },
+    },
+    F = {
+      filter = "filter_words_before_cursor",
+      metadata = { motion_state = { multi_window = true } },
+    },
+  },
+}
+```
+
+You can override any motion property this way — `extractor`, `filter`, `visualizer`, `action`, `modes`, etc.
 
 </details>
 

--- a/docs/API-Reference.md
+++ b/docs/API-Reference.md
@@ -128,8 +128,8 @@ require("smart-motion").map_motion("w")
 | `words` | Word boundaries |
 | `lines` | Entire lines |
 | `text_search_1_char` | Single char matches |
-| `text_search_1_char_until` | Single char, exclude target |
-| `text_search_2_char` | Two char matches |
+| `text_search_2_char` | Two char matches (inclusive) |
+| `text_search_2_char_until` | Two char, exclude target (till) |
 | `live_search` | Incremental search |
 | `fuzzy_search` | Fuzzy matching |
 | `pass_through` | Collector output unchanged |

--- a/docs/Building-Custom-Motions.md
+++ b/docs/Building-Custom-Motions.md
@@ -71,8 +71,8 @@ Each stage is optional (except collector, extractor, visualizer, action). Each s
 | `words` | Word boundaries via regex |
 | `lines` | Entire lines as targets |
 | `text_search_1_char` | Single character matches |
-| `text_search_1_char_until` | Single char, exclude target (for `t`/`T`) |
-| `text_search_2_char` | Two character matches |
+| `text_search_2_char` | Two character matches (for `f`/`F`) |
+| `text_search_2_char_until` | Two char, exclude target (for `t`/`T`) |
 | `live_search` | Incremental search as you type |
 | `fuzzy_search` | Fuzzy matching |
 | `pass_through` | Use collector output directly |

--- a/docs/Pipeline-Architecture.md
+++ b/docs/Pipeline-Architecture.md
@@ -198,8 +198,8 @@ A target should have:
 | `words` | Word boundaries via regex |
 | `lines` | Entire lines as targets |
 | `text_search_1_char` | Single character matches |
-| `text_search_1_char_until` | Single char with `exclude_target = true` |
-| `text_search_2_char` | Two character matches |
+| `text_search_2_char` | Two character matches (inclusive) |
+| `text_search_2_char_until` | Two char with `exclude_target = true` (till) |
 | `live_search` | Incremental search matches |
 | `fuzzy_search` | Fuzzy matched targets |
 | `pass_through` | Collector output unchanged |

--- a/lua/smart-motion/actions/utils.lua
+++ b/lua/smart-motion/actions/utils.lua
@@ -12,7 +12,8 @@ function M.merge(actions)
 end
 
 --- Resolves the operation range for an action.
---- When exclude_target is set (until mode), the range is from cursor to target.
+--- When exclude_target is set (until mode), the range is from cursor to target start (exclusive).
+--- When cursor_to_target is set (find mode), the range is from cursor to target end (inclusive).
 --- Otherwise, the range is the target itself (start_pos to end_pos).
 --- Handles both forward and backward directions automatically.
 --- @param ctx SmartMotionContext
@@ -31,6 +32,19 @@ function M.resolve_range(ctx, motion_state)
 		else
 			-- Backward until: target end → cursor (exclusive of target char)
 			return target.end_pos.row, target.end_pos.col, ctx.cursor_line, ctx.cursor_col
+		end
+	end
+
+	if motion_state.cursor_to_target then
+		local cursor_before = ctx.cursor_line < target.start_pos.row
+			or (ctx.cursor_line == target.start_pos.row and ctx.cursor_col < target.start_pos.col)
+
+		if cursor_before then
+			-- Forward find: cursor → target end (inclusive of target)
+			return ctx.cursor_line, ctx.cursor_col, target.end_pos.row, target.end_pos.col
+		else
+			-- Backward find: target start → cursor (inclusive of target)
+			return target.start_pos.row, target.start_pos.col, ctx.cursor_line, ctx.cursor_col
 		end
 	end
 

--- a/lua/smart-motion/core/engine/loop.lua
+++ b/lua/smart-motion/core/engine/loop.lua
@@ -80,17 +80,11 @@ function M.run(ctx, cfg, motion_state)
 					end
 
 					local targets = motion_state.jump_targets or {}
-					exit_event.throw_if(#targets == 0, EXIT_TYPE.EARLY_EXIT)
 
-					if #targets == 1 then
-						if cfg.auto_select_target then
-							exit_event.throw(EXIT_TYPE.AUTO_SELECT)
-						else
-							exit_event.throw(EXIT_TYPE.CONTINUE_TO_SELECTION)
-						end
+					if #targets > 0 then
+						visualizer.run(ctx, cfg, motion_state)
 					end
 
-					visualizer.run(ctx, cfg, motion_state)
 					motion_state.last_search_text = motion_state.search_text
 				end
 

--- a/lua/smart-motion/extractors/README.md
+++ b/lua/smart-motion/extractors/README.md
@@ -50,9 +50,9 @@ The `pass_through` extractor returns collector data unchanged. This is used when
 | --- | --- |
 | Extracting words from lines | `words` |
 | Extracting whole lines | `lines` |
-| 1-character search (f/F) | `text_search_1_char` |
-| 1-character until search (t/T) | `text_search_1_char_until` |
-| 2-character search | `text_search_2_char` |
+| 1-character search | `text_search_1_char` |
+| 2-character search (f/F) | `text_search_2_char` |
+| 2-character until search (t/T) | `text_search_2_char_until` |
 | Live incremental search (literal) | `live_search` |
 | Fuzzy incremental search | `fuzzy_search` |
 | Passing pre-formed targets through | `pass_through` |

--- a/lua/smart-motion/extractors/init.lua
+++ b/lua/smart-motion/extractors/init.lua
@@ -34,18 +34,18 @@ extractors.register_many({
 			motion_state = {
 				num_of_char = 1,
 				should_show_prefix = false,
+				cursor_to_target = true,
 			},
 		}),
 	},
-	text_search_1_char_until = {
+	text_search_2_char_until = {
 		keys = { "t" },
 		run = utils.module_wrapper(text_search.run, {
 			before_input_loop = text_search.before_input_loop,
 		}),
 		metadata = vim.tbl_deep_extend("force", text_search.metadata, {
 			motion_state = {
-				num_of_char = 1,
-				should_show_prefix = false,
+				num_of_char = 2,
 				exclude_target = true,
 			},
 		}),
@@ -57,6 +57,7 @@ extractors.register_many({
 		metadata = vim.tbl_deep_extend("force", text_search.metadata, {
 			motion_state = {
 				num_of_char = 2,
+				cursor_to_target = true,
 			},
 		}),
 	},
@@ -64,13 +65,21 @@ extractors.register_many({
 		run = utils.module_wrapper(live_search.run, {
 			before_input_loop = live_search.before_input_loop,
 		}),
-		metadata = live_search.metadata,
+		metadata = vim.tbl_deep_extend("force", live_search.metadata, {
+			motion_state = {
+				cursor_to_target = true,
+			},
+		}),
 	},
 	fuzzy_search = {
 		run = utils.module_wrapper(fuzzy_search.run, {
 			before_input_loop = fuzzy_search.before_input_loop,
 		}),
-		metadata = fuzzy_search.metadata,
+		metadata = vim.tbl_deep_extend("force", fuzzy_search.metadata, {
+			motion_state = {
+				cursor_to_target = true,
+			},
+		}),
 	},
 	pass_through = {
 		run = utils.module_wrapper(pass_through.run),

--- a/lua/smart-motion/presets.lua
+++ b/lua/smart-motion/presets.lua
@@ -141,40 +141,34 @@ function presets.search(exclude)
 			composable = true,
 			collector = "lines",
 			extractor = "text_search_2_char",
-			filter = "filter_words_after_cursor",
+			filter = "filter_words_on_cursor_line_after_cursor",
 			visualizer = "hint_start",
 			action = "jump_centered",
 			map = true,
 			modes = { "n", "o" },
 			metadata = {
 				label = "2 Character Find After Cursor",
-				description = "Labels 2 Character Searches and jump to target",
-				motion_state = {
-					multi_window = true,
-				},
+				description = "Labels 2 Character Searches and jump to target (line-constrained)",
 			},
 		},
 		F = {
 			composable = true,
 			collector = "lines",
 			extractor = "text_search_2_char",
-			filter = "filter_words_before_cursor",
+			filter = "filter_words_on_cursor_line_before_cursor",
 			visualizer = "hint_start",
 			action = "jump_centered",
 			map = true,
 			modes = { "n", "o" },
 			metadata = {
 				label = "2 Character Find Before Cursor",
-				description = "Labels 2 Character Searches and jump to target",
-				motion_state = {
-					multi_window = true,
-				},
+				description = "Labels 2 Character Searches and jump to target (line-constrained)",
 			},
 		},
 		t = {
 			composable = true,
 			collector = "lines",
-			extractor = "text_search_1_char_until",
+			extractor = "text_search_2_char_until",
 			filter = "filter_words_on_cursor_line_after_cursor",
 			visualizer = "hint_start",
 			action = "jump_centered",
@@ -188,7 +182,7 @@ function presets.search(exclude)
 		T = {
 			composable = true,
 			collector = "lines",
-			extractor = "text_search_1_char_until",
+			extractor = "text_search_2_char_until",
 			filter = "filter_words_on_cursor_line_before_cursor",
 			visualizer = "hint_start",
 			action = "jump_centered",
@@ -241,7 +235,7 @@ function presets.delete(exclude)
 		},
 		dt = {
 			collector = "lines",
-			extractor = "text_search_1_char_until",
+			extractor = "text_search_2_char_until",
 			filter = "filter_words_on_cursor_line_after_cursor",
 			visualizer = "hint_start",
 			action = "delete",
@@ -254,7 +248,7 @@ function presets.delete(exclude)
 		},
 		dT = {
 			collector = "lines",
-			extractor = "text_search_1_char_until",
+			extractor = "text_search_2_char_until",
 			filter = "filter_words_on_cursor_line_before_cursor",
 			visualizer = "hint_start",
 			action = "delete",
@@ -317,7 +311,7 @@ function presets.yank(exclude)
 		},
 		yt = {
 			collector = "lines",
-			extractor = "text_search_1_char_until",
+			extractor = "text_search_2_char_until",
 			filter = "filter_words_on_cursor_line_after_cursor",
 			visualizer = "hint_start",
 			action = "yank_until",
@@ -330,7 +324,7 @@ function presets.yank(exclude)
 		},
 		yT = {
 			collector = "lines",
-			extractor = "text_search_1_char_until",
+			extractor = "text_search_2_char_until",
 			filter = "filter_words_on_cursor_line_before_cursor",
 			visualizer = "hint_start",
 			action = "yank_until",
@@ -393,7 +387,7 @@ function presets.change(exclude)
 		},
 		ct = {
 			collector = "lines",
-			extractor = "text_search_1_char_until",
+			extractor = "text_search_2_char_until",
 			filter = "filter_words_on_cursor_line_after_cursor",
 			visualizer = "hint_start",
 			action = "change_until",
@@ -406,7 +400,7 @@ function presets.change(exclude)
 		},
 		cT = {
 			collector = "lines",
-			extractor = "text_search_1_char_until",
+			extractor = "text_search_2_char_until",
 			filter = "filter_words_on_cursor_line_before_cursor",
 			visualizer = "hint_start",
 			action = "change_until",
@@ -460,8 +454,13 @@ end
 function presets.misc(exclude)
 	-- Function node types for quickfix output
 	local function_node_types = {
-		"function_declaration", "function_definition", "arrow_function",
-		"method_definition", "function_item", "method_declaration", "method",
+		"function_declaration",
+		"function_definition",
+		"arrow_function",
+		"method_definition",
+		"function_item",
+		"method_declaration",
+		"method",
 	}
 
 	presets._register({
@@ -719,18 +718,37 @@ function presets.treesitter(exclude)
 
 	local scope_node_types = {
 		-- Control flow
-		"if_statement", "if_expression", "else_clause", "elif_clause",
-		"switch_statement", "switch_expression", "match_expression",
-		"case_statement", "case_clause",
+		"if_statement",
+		"if_expression",
+		"else_clause",
+		"elif_clause",
+		"switch_statement",
+		"switch_expression",
+		"match_expression",
+		"case_statement",
+		"case_clause",
 		-- Loops
-		"while_statement", "while_expression",
-		"for_statement", "for_expression", "for_in_statement", "for_of_statement",
-		"do_statement", "loop_expression", "repeat_statement",
+		"while_statement",
+		"while_expression",
+		"for_statement",
+		"for_expression",
+		"for_in_statement",
+		"for_of_statement",
+		"do_statement",
+		"loop_expression",
+		"repeat_statement",
 		-- Exception handling
-		"try_statement", "catch_clause", "except_clause", "finally_clause",
+		"try_statement",
+		"catch_clause",
+		"except_clause",
+		"finally_clause",
 		-- Blocks/closures
-		"block", "closure_expression", "lambda", "lambda_expression",
-		"with_statement", "do_block",
+		"block",
+		"closure_expression",
+		"lambda",
+		"lambda_expression",
+		"with_statement",
+		"do_block",
 	}
 
 	presets._register({

--- a/lua/smart-motion/types.lua
+++ b/lua/smart-motion/types.lua
@@ -95,6 +95,7 @@
 --- @field last_search_text? string | nil
 --- @field is_searching_mode? boolean
 --- @field exclude_target? boolean -- Used to exclude hinted character and act like "until"
+--- @field cursor_to_target? boolean -- Range from cursor to target end (inclusive find mode)
 --- @field num_of_char? number
 --- @field should_show_prefix? boolean
 --- @field allow_quick_action? boolean -- Used to control if we should run action on target under cursor

--- a/tests/search.lua
+++ b/tests/search.lua
@@ -27,30 +27,30 @@
 -- ── Section 1: Repeated patterns for search ───────────────────
 
 local function create_handler(name, callback)
-  return {
-    name = name,
-    callback = callback,
-    enabled = true,
-    priority = 0,
-  }
+	return {
+		name = name,
+		callback = callback,
+		enabled = true,
+		priority = 0,
+	}
 end
 
 local function create_middleware(name, transform)
-  return {
-    name = name,
-    transform = transform,
-    enabled = true,
-    priority = 0,
-  }
+	return {
+		name = name,
+		transform = transform,
+		enabled = true,
+		priority = 0,
+	}
 end
 
 local function create_validator(name, validate)
-  return {
-    name = name,
-    validate = validate,
-    enabled = true,
-    priority = 0,
-  }
+	return {
+		name = name,
+		validate = validate,
+		enabled = true,
+		priority = 0,
+	}
 end
 
 -- Try: s then type "name" — multiple matches highlighted
@@ -60,35 +60,35 @@ end
 -- ── Section 2: Varied vocabulary for f/F ──────────────────────
 
 local database = {
-  host = "localhost",
-  port = 5432,
-  username = "admin",
-  password = "secret",
-  database = "myapp_production",
-  pool_size = 10,
-  timeout = 30000,
-  ssl_enabled = true,
-  ssl_ca_cert = "/etc/ssl/certs/ca.pem",
-  retry_count = 3,
-  retry_delay = 1000,
+	host = "localhost",
+	port = 5432,
+	username = "admin",
+	password = "secret",
+	database = "myapp_production",
+	pool_size = 10,
+	timeout = 30000,
+	ssl_enabled = true,
+	ssl_ca_cert = "/etc/ssl/certs/ca.pem",
+	retry_count = 3,
+	retry_delay = 1000,
 }
 
 local redis_config = {
-  host = "127.0.0.1",
-  port = 6379,
-  prefix = "myapp:",
-  ttl = 3600,
-  max_memory = "256mb",
-  eviction_policy = "allkeys-lru",
+	host = "127.0.0.1",
+	port = 6379,
+	prefix = "myapp:",
+	ttl = 3600,
+	max_memory = "256mb",
+	eviction_policy = "allkeys-lru",
 }
 
 local elasticsearch = {
-  nodes = { "http://es01:9200", "http://es02:9200", "http://es03:9200" },
-  index_prefix = "logs-",
-  bulk_size = 1000,
-  flush_interval = 5,
-  number_of_shards = 3,
-  number_of_replicas = 1,
+	nodes = { "http://es01:9200", "http://es02:9200", "http://es03:9200" },
+	index_prefix = "logs-",
+	bulk_size = 1000,
+	flush_interval = 5,
+	number_of_shards = 3,
+	number_of_replicas = 1,
 }
 
 -- Try: f then "ho" — matches "host" in database, redis_config
@@ -101,11 +101,11 @@ local elasticsearch = {
 -- Result: visual selection spanning "quick brown fox jumps over the lazy"
 
 local pangrams = {
-  "the quick brown fox jumps over the lazy dog",
-  "pack my box with five dozen liquor jugs",
-  "how vexingly quick daft zebras jump",
-  "the five boxing wizards jump quickly",
-  "sphinx of black quartz judge my vow",
+	"the quick brown fox jumps over the lazy dog",
+	"pack my box with five dozen liquor jugs",
+	"how vexingly quick daft zebras jump",
+	"the five boxing wizards jump quickly",
+	"sphinx of black quartz judge my vow",
 }
 
 local lorem = [[
@@ -123,57 +123,57 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia.
 -- After t or T, press ; to repeat, , to reverse
 
 local function parse_arguments(input_string)
-  local args = {}
-  local current = ""
-  local depth = 0
-  for i = 1, #input_string do
-    local char = input_string:sub(i, i)
-    if char == "(" then
-      depth = depth + 1
-      current = current .. char
-    elseif char == ")" then
-      depth = depth - 1
-      current = current .. char
-    elseif char == "," and depth == 0 then
-      args[#args + 1] = current:match("^%s*(.-)%s*$")
-      current = ""
-    else
-      current = current .. char
-    end
-  end
-  if #current > 0 then
-    args[#args + 1] = current:match("^%s*(.-)%s*$")
-  end
-  return args
+	local args = {}
+	local current = ""
+	local depth = 0
+	for i = 1, #input_string do
+		local char = input_string:sub(i, i)
+		if char == "(" then
+			depth = depth + 1
+			current = current .. char
+		elseif char == ")" then
+			depth = depth - 1
+			current = current .. char
+		elseif char == "," and depth == 0 then
+			args[#args + 1] = current:match("^%s*(.-)%s*$")
+			current = ""
+		else
+			current = current .. char
+		end
+	end
+	if #current > 0 then
+		args[#args + 1] = current:match("^%s*(.-)%s*$")
+	end
+	return args
 end
 
 local function build_query(table_name, conditions, order_by, limit)
-  local query = "SELECT * FROM " .. table_name
-  if conditions and #conditions > 0 then
-    query = query .. " WHERE " .. table.concat(conditions, " AND ")
-  end
-  if order_by then
-    query = query .. " ORDER BY " .. order_by
-  end
-  if limit then
-    query = query .. " LIMIT " .. tostring(limit)
-  end
-  return query
+	local query = "SELECT * FROM " .. table_name
+	if conditions and #conditions > 0 then
+		query = query .. " WHERE " .. table.concat(conditions, " AND ")
+	end
+	if order_by then
+		query = query .. " ORDER BY " .. order_by
+	end
+	if limit then
+		query = query .. " LIMIT " .. tostring(limit)
+	end
+	return query
 end
 
 local function format_duration(milliseconds)
-  local seconds = math.floor(milliseconds / 1000)
-  local minutes = math.floor(seconds / 60)
-  local hours = math.floor(minutes / 60)
-  seconds = seconds % 60
-  minutes = minutes % 60
-  if hours > 0 then
-    return string.format("%dh %dm %ds", hours, minutes, seconds)
-  elseif minutes > 0 then
-    return string.format("%dm %ds", minutes, seconds)
-  else
-    return string.format("%ds", seconds)
-  end
+	local seconds = math.floor(milliseconds / 1000)
+	local minutes = math.floor(seconds / 60)
+	local hours = math.floor(minutes / 60)
+	seconds = seconds % 60
+	minutes = minutes % 60
+	if hours > 0 then
+		return string.format("%dh %dm %ds", hours, minutes, seconds)
+	elseif minutes > 0 then
+		return string.format("%dm %ds", minutes, seconds)
+	else
+		return string.format("%ds", seconds)
+	end
 end
 
 -- ── Section 5: ; and , repeat testing ─────────────────────────
@@ -204,29 +204,29 @@ local juliet = "tenth"
 -- Select a label from the other window to jump across
 
 local function connect(host, port)
-  print(string.format("Connecting to %s:%d", host, port))
-  return { host = host, port = port, connected = true }
+	print(string.format("Connecting to %s:%d", host, port))
+	return { host = host, port = port, connected = true }
 end
 
 local function disconnect(connection)
-  connection.connected = false
-  print(string.format("Disconnected from %s:%d", connection.host, connection.port))
+	connection.connected = false
+	print(string.format("Disconnected from %s:%d", connection.host, connection.port))
 end
 
 local function send_message(connection, message)
-  if not connection.connected then
-    error("Not connected")
-  end
-  print(string.format("Sending to %s: %s", connection.host, message))
+	if not connection.connected then
+		error("Not connected")
+	end
+	print(string.format("Sending to %s: %s", connection.host, message))
 end
 
 local function receive_message(connection, timeout)
-  if not connection.connected then
-    error("Not connected")
-  end
-  timeout = timeout or 5000
-  print(string.format("Waiting %dms for message from %s", timeout, connection.host))
-  return "response"
+	if not connection.connected then
+		error("Not connected")
+	end
+	timeout = timeout or 5000
+	print(string.format("Waiting %dms for message from %s", timeout, connection.host))
+	return "response"
 end
 
 -- ── Section 7: Fuzzy search with S ─────────────────────────────
@@ -239,44 +239,44 @@ end
 --   "usr" → matches "user", "username", "userService"
 
 local function createUserService(config)
-  return {
-    config = config,
-    users = {},
-    authenticate = function(self, username, password)
-      return self.users[username] and self.users[username].password == password
-    end,
-  }
+	return {
+		config = config,
+		users = {},
+		authenticate = function(self, username, password)
+			return self.users[username] and self.users[username].password == password
+		end,
+	}
 end
 
 local function configureApplication(settings)
-  local configuration = {
-    debug = settings.debug or false,
-    logLevel = settings.logLevel or "info",
-    maxConnections = settings.maxConnections or 100,
-  }
-  return configuration
+	local configuration = {
+		debug = settings.debug or false,
+		logLevel = settings.logLevel or "info",
+		maxConnections = settings.maxConnections or 100,
+	}
+	return configuration
 end
 
 local function fetchUserProfile(userId)
-  local firstName = "John"
-  local lastName = "Doe"
-  local userEmail = "john.doe@example.com"
-  return {
-    id = userId,
-    firstName = firstName,
-    lastName = lastName,
-    email = userEmail,
-  }
+	local firstName = "John"
+	local lastName = "Doe"
+	local userEmail = "john.doe@example.com"
+	return {
+		id = userId,
+		firstName = firstName,
+		lastName = lastName,
+		email = userEmail,
+	}
 end
 
 local function validateUsername(username)
-  if not username or #username < 3 then
-    return false, "Username too short"
-  end
-  if username:match("[^%w_]") then
-    return false, "Username contains invalid characters"
-  end
-  return true
+	if not username or #username < 3 then
+		return false, "Username too short"
+	end
+	if username:match("[^%w_]") then
+		return false, "Username contains invalid characters"
+	end
+	return true
 end
 
 -- Try: S then "fn" — matches function, firstName


### PR DESCRIPTION
- Fix cf/cF/df/dF/yf/yF operating on wrong range: was only acting on the matched characters instead of cursor-to-target. Added cursor_to_target flag to resolve_range() for inclusive find semantics.
- Also fix ds/cs/ys and dS/cS/yS with the same cursor_to_target fix.
- Make t/T 2-char searches (matching f/F) — f/t are now a clean inclusive/exclusive pair with the same search method.
- Make f/F line-constrained by default (matching t/T). Added docs showing how to customize to multi-line or multi-window.
- Don't auto-exit search loop when only 1 target remains (s/S can keep refining).
- Don't abort search on 0 matches (user can backspace and retry).

Fixes: #98