### PR TITLE
feat: add open_folds_on_jump config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ SmartMotion wouldn't exist without these plugins. See [Why SmartMotion](https://
   native_search = true,              -- labels during / search
   count_behavior = "target",         -- "target" or "native" for j/k counts
   history_max_size = 20,             -- persistent history entries
+  open_folds_on_jump = true,         -- open folds at target position
 }
 ```
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -46,6 +46,9 @@ Complete guide to configuring SmartMotion.
 
   -- How count prefix interacts with motions (j/k), "target" or "native"
   count_behavior = "target",
+
+  -- Open folds at target position after jumping
+  open_folds_on_jump = true,
 }
 ```
 
@@ -299,6 +302,21 @@ disable_dim_background = true   -- dimming disabled
 
 ---
 
+## Fold Handling
+
+Control whether folds are opened when jumping to a target:
+
+```lua
+open_folds_on_jump = true   -- open folds at target (default)
+open_folds_on_jump = false  -- keep folds closed
+```
+
+When enabled, SmartMotion runs `zv` after every jump to reveal the target line. This applies to all jump actions including pipeline jumps, history navigation, and pin jumps.
+
+Disable this if you prefer folds to stay closed and want to open them manually.
+
+---
+
 ## History
 
 Configure motion history size:
@@ -367,6 +385,9 @@ See **[Advanced Features: Motion History](Advanced-Features.md#motion-history)**
 
     -- Disable native search labels
     native_search = false,
+
+    -- Keep folds closed when jumping
+    open_folds_on_jump = false,
   },
 }
 ```

--- a/docs/Quick-Start.md
+++ b/docs/Quick-Start.md
@@ -179,6 +179,9 @@ opts = {
 
   -- Dim non-target text
   disable_dim_background = false,
+
+  -- Open folds at target position after jumping
+  open_folds_on_jump = true,
 }
 ```
 

--- a/lua/smart-motion/actions/history_browse.lua
+++ b/lua/smart-motion/actions/history_browse.lua
@@ -115,7 +115,10 @@ function M._navigate(entry)
 	end
 	local col = math.max(target.start_pos.col, 0)
 	pcall(vim.api.nvim_win_set_cursor, 0, { row, col })
-	vim.cmd("normal! zv")
+	local config = require("smart-motion.config")
+	if not config.validated or config.validated.open_folds_on_jump then
+		vim.cmd("normal! zv")
+	end
 end
 
 --- Executes a remote action on a history entry's target.

--- a/lua/smart-motion/actions/jump.lua
+++ b/lua/smart-motion/actions/jump.lua
@@ -87,7 +87,7 @@ function M.run(ctx, cfg, motion_state)
 	end
 
 	-- Open any folds at the target position
-	if not is_op_pending then
+	if not is_op_pending and cfg.open_folds_on_jump then
 		vim.cmd("normal! zv")
 	end
 

--- a/lua/smart-motion/config.lua
+++ b/lua/smart-motion/config.lua
@@ -29,6 +29,7 @@ M.defaults = {
 	auto_select_target = false,
 	native_search = true,
 	count_behavior = "target",
+	open_folds_on_jump = true,
 }
 
 ---@type SmartMotionConfig
@@ -155,6 +156,13 @@ function M.validate(user_config)
 	--
 	if config.count_behavior ~= "target" and config.count_behavior ~= "native" then
 		config.count_behavior = "target"
+	end
+
+	--
+	-- Validate open_folds_on_jump
+	--
+	if config.open_folds_on_jump == nil or type(config.open_folds_on_jump) ~= "boolean" then
+		config.open_folds_on_jump = true
 	end
 
 	M.validated = config

--- a/lua/smart-motion/core/history.lua
+++ b/lua/smart-motion/core/history.lua
@@ -193,7 +193,10 @@ function M.jump_to_pin(n)
 		row = line_count
 	end
 	vim.api.nvim_win_set_cursor(0, { row, col })
-	vim.cmd("normal! zv") -- Open folds
+	local config = require("smart-motion.config")
+	if not config.validated or config.validated.open_folds_on_jump then
+		vim.cmd("normal! zv") -- Open folds
+	end
 end
 
 --- Jumps to the most recent history entry.
@@ -232,7 +235,10 @@ function M.jump_to_recent()
 		row = line_count
 	end
 	vim.api.nvim_win_set_cursor(0, { row, col })
-	vim.cmd("normal! zv") -- Open folds
+	local config = require("smart-motion.config")
+	if not config.validated or config.validated.open_folds_on_jump then
+		vim.cmd("normal! zv") -- Open folds
+	end
 end
 
 --- Sets the current cursor location as pin at slot n (1-based).
@@ -461,7 +467,10 @@ function M.jump_to_global_pin(letter)
 		row = line_count
 	end
 	vim.api.nvim_win_set_cursor(0, { row, col })
-	vim.cmd("normal! zv")
+	local config = require("smart-motion.config")
+	if not config.validated or config.validated.open_folds_on_jump then
+		vim.cmd("normal! zv")
+	end
 end
 
 --- Saves global pins to disk.

--- a/lua/smart-motion/types.lua
+++ b/lua/smart-motion/types.lua
@@ -21,6 +21,7 @@
 ---@field disable_dim_background boolean
 ---@field native_search? boolean
 ---@field count_behavior? "target" | "native"
+---@field open_folds_on_jump? boolean
 
 ---@class SmartMotionPresets
 ---@field words? true | SmartMotionPresetKey.Words[]


### PR DESCRIPTION
Allow users to disable automatic fold opening (zv) after jumping. Defaults to true to preserve existing behavior. Gates all 5 zv call sites: jump action, history browse, pin jump, recent jump, and global pin jump.