### PR TITLE
fix: update WORD_PATTERN to match native vim w motion behavior

### DIFF
--- a/lua/smart-motion/consts.lua
+++ b/lua/smart-motion/consts.lua
@@ -43,8 +43,7 @@ M.TARGET_TYPES_BY_KEY = {
 	s = "search",
 }
 
-M.WORD_PATTERN = [[\k\+]]
-M.WORD_WITH_PUNCTUATION_PATTERN = [[\k\+|[](){}.,=+%-]]
+M.WORD_PATTERN = [[\k\+\|\%(\k\@!\S\)\+]]
 M.BIG_WORD_PATTERN = [[[^ \t]\+]]
 
 ---@type table<string, SelectionMode>


### PR DESCRIPTION
Include non-keyword non-whitespace sequences (punctuation) as separate word targets, matching how native vim treats three character classes (keyword, punctuation, whitespace). Remove unused WORD_WITH_PUNCTUATION_PATTERN.