### PR TITLE
docs: update word_pattern references to reflect new default

### DIFF
--- a/docs/API-Reference.md
+++ b/docs/API-Reference.md
@@ -303,7 +303,7 @@ The `motion_state` table is mutable state passed through all pipeline stages.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `word_pattern` | string | Custom word regex |
+| `word_pattern` | string | Custom word regex (default: `\k\+\|\%(\k\@!\S\)\+` — keyword sequences or punctuation sequences, matching native vim `w`) |
 
 ---
 

--- a/docs/Advanced-Recipes.md
+++ b/docs/Advanced-Recipes.md
@@ -142,7 +142,7 @@ require("smart-motion").register_motion("<leader>t", {
 })
 ```
 
-**How it works:** The `words` extractor uses the custom `word_pattern` regex instead of the default word boundary pattern. It matches only TODO-style comment tags. The `lines` collector feeds all visible buffer lines, and `multi_window = true` searches across every open split.
+**How it works:** The `words` extractor uses the custom `word_pattern` regex instead of the default (`\k\+\|\%(\k\@!\S\)\+` — keyword sequences or punctuation sequences). It matches only TODO-style comment tags. The `lines` collector feeds all visible buffer lines, and `multi_window = true` searches across every open split.
 
 ### Jump to Only Errors
 

--- a/docs/Recipes.md
+++ b/docs/Recipes.md
@@ -209,7 +209,7 @@ Extractors determine *what kind of targets* appear.
 
 | Name | What it finds |
 |------|---------------|
-| `words` | Word boundaries (respects `word_pattern` metadata) |
+| `words` | Word boundaries matching native vim `w` — keyword sequences and punctuation sequences (respects `word_pattern` metadata) |
 | `lines` | Line starts (non-blank lines) |
 | `text_search_1_char` | Matches after typing 1 character |
 | `text_search_2_char` | Matches after typing 2 characters (inclusive) |
@@ -417,7 +417,7 @@ presets = {
 }
 ```
 
-**What changed:** The `motion_state.word_pattern` metadata tells the `words` extractor to use a custom regex. This pattern splits `camelCaseWord` into `camel`, `Case`, and `Word` as separate targets.
+**What changed:** The `motion_state.word_pattern` metadata tells the `words` extractor to use a custom regex instead of the default (`\k\+\|\%(\k\@!\S\)\+` — keyword sequences or punctuation sequences). This pattern splits `camelCaseWord` into `camel`, `Case`, and `Word` as separate targets.
 
 ### Bidirectional words
 


### PR DESCRIPTION
The default word_pattern now matches native vim w behavior (keyword sequences or punctuation sequences).