### PR TITLE
feat: add per-motion keys and exclude_keys label customization

### DIFF
--- a/lua/smart-motion/presets.lua
+++ b/lua/smart-motion/presets.lua
@@ -1291,6 +1291,21 @@ function presets._register(motions_list, user_overrides)
 
 		-- Merge override into motion config if table provider
 		if type(override) == "table" then
+			-- Route label customization keys into metadata.motion_state
+			-- to avoid conflict with the motion entry's `keys` property (used for action key mapping)
+			if override.keys or override.exclude_keys then
+				override = vim.tbl_deep_extend("force", {}, override)
+				override.metadata = override.metadata or {}
+				override.metadata.motion_state = override.metadata.motion_state or {}
+				if override.keys then
+					override.metadata.motion_state.label_keys = override.keys
+					override.keys = nil
+				end
+				if override.exclude_keys then
+					override.metadata.motion_state.exclude_label_keys = override.exclude_keys
+					override.exclude_keys = nil
+				end
+			end
 			final_motions[name] = vim.tbl_deep_extend("force", motion, override)
 		else
 			-- No override, use default motion


### PR DESCRIPTION
Allow users to customize the label pool on a per-motion basis via preset overrides. This addresses the issue where certain label keys (e.g., j/k) interfere with line motions when the user is slightly too slow.

fixes: #110 