### PR TITLE
fix: prevent j/k motions from polluting the jumplist

### DIFF
--- a/lua/smart-motion/actions/jump.lua
+++ b/lua/smart-motion/actions/jump.lua
@@ -53,7 +53,8 @@ function M.run(ctx, cfg, motion_state)
 	end
 
 	-- Save current position to jumplist before moving
-	if cfg.save_to_jumplist then
+	-- Skip for motions like j/k that shouldn't pollute the jumplist (matching native vim)
+	if cfg.save_to_jumplist and not motion_state.skip_jumplist then
 		vim.cmd("normal! m'")
 	end
 

--- a/lua/smart-motion/presets.lua
+++ b/lua/smart-motion/presets.lua
@@ -80,6 +80,9 @@ function presets.lines(exclude)
 			metadata = {
 				label = "Jump to Line after cursor",
 				description = "Jumps to the start of the line after the cursor",
+				motion_state = {
+					skip_jumplist = true,
+				},
 			},
 		},
 		k = {
@@ -95,6 +98,9 @@ function presets.lines(exclude)
 			metadata = {
 				label = "Jump to Line before cursor",
 				description = "Jumps to the start of the line before the cursor",
+				motion_state = {
+					skip_jumplist = true,
+				},
 			},
 		},
 	}, exclude)

--- a/lua/smart-motion/types.lua
+++ b/lua/smart-motion/types.lua
@@ -120,6 +120,7 @@
 --- @field ts_yield_children? boolean -- Yield named children of matched container nodes
 --- @field ts_around_separator? boolean -- Expand child ranges to include surrounding separators
 --- @field diagnostic_severity? integer|integer[] -- Filter diagnostics by severity
+--- @field skip_jumplist? boolean -- Skip saving to jumplist (for motions like j/k that match native vim behavior)
 --- @field motion SmartMotionMotionEntry
 
 ---@class SmartMotionTarget


### PR DESCRIPTION
Native vim's j/k movements don't add entries to the jumplist (ctrl+o/ctrl+i), but smart-motion's j/k were unconditionally saving to the jumplist via the jump action. This made ctrl+o/ctrl+i unusable since every line movement was recorded. Add skip_jumplist flag to j/k presets to match native vim behavior.

Fixes: #114 