### PR TITLE
fix: excluded motion key now jumps to nearest target instead of cancelling

### DIFF
--- a/lua/smart-motion/core/engine/setup.lua
+++ b/lua/smart-motion/core/engine/setup.lua
@@ -19,6 +19,10 @@ function M.run(trigger_key)
 	-- Shallow copy so infer mutations don't leak to the registry entry
 	motion_state.motion = vim.tbl_extend("force", {}, motion)
 
+	-- Set motion_key to the trigger key for direct motions.
+	-- For operator motions (infer=true), infer.run will override this with the composed key.
+	motion_state.motion_key = trigger_key
+
 	local modules = module_loader.get_modules(ctx, cfg, motion_state)
 
 	-- The modules might have motion_state they would like to set

--- a/lua/smart-motion/core/selection.lua
+++ b/lua/smart-motion/core/selection.lua
@@ -31,10 +31,19 @@ function M.wait_for_hint_selection(ctx, cfg, motion_state)
 	-- Repeat motion key = act on target under cursor (e.g., dww deletes cursor word)
 	-- Must check BEFORE flow state evaluation — otherwise quick typing triggers
 	-- "jump early" which selects the first target instead of the cursor target.
-	if motion_state.allow_quick_action and motion_state.motion_key and char == motion_state.motion_key then
-		local under_cursor = targets.get_target_under_cursor(ctx, cfg, motion_state)
-		if under_cursor then
-			motion_state.selected_jump_target = under_cursor
+	if motion_state.motion_key and char == motion_state.motion_key then
+		if motion_state.allow_quick_action then
+			local under_cursor = targets.get_target_under_cursor(ctx, cfg, motion_state)
+			if under_cursor then
+				motion_state.selected_jump_target = under_cursor
+				return
+			end
+		elseif motion_state.exclude_label_keys
+			and motion_state.exclude_label_keys:lower():find(char:lower(), 1, true)
+		then
+			-- The motion key was excluded from the label pool via exclude_label_keys.
+			-- Pressing it selects the nearest target (targets[1]) instead of cancelling.
+			-- e.g. j = { exclude_keys = "jk" }: pressing j again always goes down one line.
 			return
 		end
 	end


### PR DESCRIPTION
## Summary

- Fixes the behavior where pressing an `exclude_keys` key during label selection (e.g. pressing `j` again with `j = { exclude_keys = "jk" }`) would cancel with no movement
- Now correctly jumps to the nearest target in the motion direction — consistent with flow state fast-press behavior
- Adds `motion_state.motion_key` tracking for all direct motions (previously only set for operator compositions via infer)

## Root Cause

`motion_state.motion_key` was only set in `infer.lua` (for operator motions like `dw`, `dj`). For direct motions like `j`, it was always `nil`, so the repeat-key check in `selection.lua` never fired.

## Changes

- `core/engine/setup.lua`: set `motion_state.motion_key = trigger_key` for all motions; `infer.run` still overrides this for compositions
- `core/selection.lua`: when pressed key matches `motion_key` and that key is in `exclude_label_keys`, return without cancelling so `targets[1]` (nearest target) is used

## Test plan

- [x] `j = { exclude_keys = "jk" }`: pressing `j` slowly after labels appear jumps down one line
- [x] `k = { exclude_keys = "jk" }`: pressing `k` slowly after labels appear jumps up one line
- [x] `dw` + pressing `w` again still selects cursor word (allow_quick_action path unchanged)
- [x] `djj` (operator + j + j) still works as before
- [x] Pressing an unrelated excluded key (e.g. `k` during `j` label selection) still cancels

Closes #110