### PR TITLE
fix: refresh flow timestamp on excluded-key repeat, remove dead motion_key variable

### DIFF
--- a/lua/smart-motion/core/selection.lua
+++ b/lua/smart-motion/core/selection.lua
@@ -44,6 +44,8 @@ function M.wait_for_hint_selection(ctx, cfg, motion_state)
 			-- The motion key was excluded from the label pool via exclude_label_keys.
 			-- Pressing it selects the nearest target (targets[1]) instead of cancelling.
 			-- e.g. j = { exclude_keys = "jk" }: pressing j again always goes down one line.
+			-- Refresh the timestamp so chained presses (jjjj) keep the flow window alive.
+			flow_state.refresh_timestamp()
 			return
 		end
 	end

--- a/lua/smart-motion/utils/module_loader.lua
+++ b/lua/smart-motion/utils/module_loader.lua
@@ -10,7 +10,6 @@ function M.get_modules(ctx, cfg, motion_state, keys)
 	local registries = require("smart-motion.core.registries"):get()
 	local motion = motion_state.motion
 	local action_key = motion.action_key
-	local motion_key = motion_state.motion_key
 	local modules = {}
 
 	local default_keys = { "collector", "extractor", "modifier", "filter", "visualizer", "action" }


### PR DESCRIPTION
## Summary

Follow-up to #117 — two small fixes found while reviewing related code.

- **Flow timestamp refresh**: When pressing an `exclude_keys` key during label selection (e.g. `jj` with `j = { exclude_keys = "jk" }`), `evaluate_flow_at_selection()` was never called, so the flow window was measured from the *first* keypress instead of the most recent one. For chained presses (`jjjjj`), the chain could expire earlier than expected. Now calls `flow_state.refresh_timestamp()` in that path.
- **Dead code removal**: `module_loader.lua` was reading `local motion_key = motion_state.motion_key` but never using the variable — a leftover from the old extractor-key lookup system that was removed when motion-based inference was introduced.

## Test plan

- [x] `jjjjj` with `j = { exclude_keys = "jk" }` chains correctly without expiring early
- [x] No regression on `dw`/`dj`/`dj` operator compositions