### PR TITLE
Selection handlers & pipeline-modifying support

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,12 @@ SmartMotion wouldn't exist without these plugins. See [Why SmartMotion](https://
   search_idle_timeout_ms = 2000,     -- exit search with no input
   yank_highlight_duration = 150,     -- yank flash duration (ms)
   history_max_age_days = 30,         -- prune history entries older than this
+  selection_keys = {                  -- key-action map during label selection
+    ["<CR>"]  = "select_first",      -- Enter picks the first target
+    ["<M-d>"] = "toggle_direction",  -- Flip search direction
+    ["<M-w>"] = "toggle_multi_window", -- Toggle single/multi-window
+    ["<M-e>"] = "expand_search_scope", -- Double the search scope
+  },
 }
 ```
 

--- a/docs/Advanced-Features.md
+++ b/docs/Advanced-Features.md
@@ -84,6 +84,118 @@ ds + ... = delete via search    df + .. = delete via 2-char find
 
 ---
 
+## Selection Handlers
+
+During label selection, special keys can trigger **selection handlers** — registered actions that modify the selection flow. Three built-in handlers ship with SmartMotion.
+
+### Select First / Select Last
+
+Press `<CR>` during label selection to instantly select the first target. This bridges the gap between SmartMotion's label-based selection and vanilla Vim behavior.
+
+Search motions like `f`, `t`, and `s` always require reading and pressing a label, even when you want the closest match. Unlike `dww` (repeat the motion key) or flow state (`jj`), there's no quick shortcut for "just give me the first one."
+
+```
+fa<CR>    jump to the first "a" (vanilla f behavior)
+ta<CR>    jump to just before the first "a" (vanilla t behavior)
+sa<CR>    jump to the first "a" search match
+dw<CR>    delete to the first word target
+```
+
+`select_last` does the inverse — selects the furthest target. Not mapped by default; add it to your config:
+
+```lua
+selection_keys = {
+    ["<CR>"] = "select_first",
+    ["<S-CR>"] = "select_last",
+}
+```
+
+### Toggle Hint Position
+
+Flips hint labels between the start and end of each target. Useful when a hint overlaps text you're trying to read. Not mapped by default:
+
+```lua
+selection_keys = {
+    ["<CR>"] = "select_first",
+    ["<M-h>"] = "toggle_hint_position",
+}
+```
+
+Press the toggle key during label selection — hints re-render at the opposite end of each target. Press it again to flip back. Then pick your label as usual.
+
+### Pipeline-Modifying Handlers
+
+Some selection handlers can re-run the entire motion pipeline during label selection.
+This lets you change the search context without cancelling and re-triggering the motion.
+
+**Built-in pipeline-modifying handlers:**
+
+- `toggle_direction` (`<M-d>`) — Flip between forward and backward search. Press during
+  `w` labels to switch to backward words, or during `s` results to search the other direction.
+
+- `toggle_multi_window` (`<M-w>`) — Toggle between single-window and multi-window target
+  collection. Expand a word motion to show targets across all visible windows.
+
+- `expand_search_scope` (`<M-e>`) — Double the search scope (max_lines). Press multiple
+  times to progressively expand. Useful when the target you want is just outside the
+  initial scope.
+
+**How it works:** When these handlers are triggered, the plugin:
+1. Resets targets and labels
+2. Re-runs the pipeline with the modified `motion_state`
+3. Regenerates and renders new hint labels
+4. Returns to the selection loop for your next keypress
+
+If the re-run produces no targets (e.g., toggling direction when nothing is behind the
+cursor), the motion cancels gracefully.
+
+### Relationship to Other Shortcuts
+
+SmartMotion has several ways to "skip" or modify label selection:
+
+| Method | How | Best for |
+|--------|-----|----------|
+| **Flow state** | Press motion key quickly after a previous motion | Chaining motions (`w` → `w` → `j`) |
+| **Repeat motion key** | Press motion key during labels (`dww`) | Acting on cursor target |
+| **Select first target** | Press `<CR>` during labels | Picking the closest match |
+| **Toggle hint position** | Press configured key during labels | Reading obscured text |
+| **Toggle direction** | Press `<M-d>` during labels | Flipping search direction |
+| **Toggle multi-window** | Press `<M-w>` during labels | Expanding to all windows |
+| **Expand search scope** | Press `<M-e>` during labels | Reaching further targets |
+
+All coexist. Selection handlers are checked after the motion-key-repeat check, so `dww` still works as expected.
+
+### Configuration
+
+Enabled by default with four mappings. The `selection_keys` config maps keys to registered handlers:
+
+```lua
+-- Default
+selection_keys = {
+    ["<CR>"]  = "select_first",
+    ["<M-d>"] = "toggle_direction",
+    ["<M-w>"] = "toggle_multi_window",
+    ["<M-e>"] = "expand_search_scope",
+}
+
+-- Full example
+selection_keys = {
+    ["<CR>"]  = "select_first",
+    ["<S-CR>"] = "select_last",
+    ["<M-h>"] = "toggle_hint_position",
+    ["<M-d>"] = "toggle_direction",
+    ["<M-w>"] = "toggle_multi_window",
+    ["<M-e>"] = "expand_search_scope",
+}
+
+-- Disable
+selection_keys = false
+```
+
+See **[Configuration: Selection Keys](Configuration.md#selection-keys)** for details.
+
+---
+
 ## Operator-Pending Mode
 
 SmartMotion motions work with **any vim operator**.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -67,6 +67,14 @@ Complete guide to configuring SmartMotion.
 
   -- Prune history entries older than this many days
   history_max_age_days = 30,
+
+  -- Key-action map for label selection (press key to trigger action)
+  selection_keys = {
+    ["<CR>"]  = "select_first",       -- Enter selects the first target
+    ["<M-d>"] = "toggle_direction",   -- Flip search direction
+    ["<M-w>"] = "toggle_multi_window", -- Toggle single/multi-window
+    ["<M-e>"] = "expand_search_scope", -- Double the search scope
+  },
 }
 ```
 
@@ -452,6 +460,98 @@ See **[Advanced Features: Motion History](Advanced-Features.md#motion-history)**
 
 ---
 
+## Selection Keys
+
+Configure special keys that trigger actions during label selection:
+
+```lua
+selection_keys = {
+    ["<CR>"]  = "select_first",
+    ["<M-d>"] = "toggle_direction",
+    ["<M-w>"] = "toggle_multi_window",
+    ["<M-e>"] = "expand_search_scope",
+}
+```
+
+**How it works:**
+1. A motion triggers and labels appear
+2. Instead of pressing a label, press a configured key
+3. The corresponding handler runs
+
+### Built-in Handlers
+
+| Handler Name | Default Key | Return | Description |
+|---|---|---|---|
+| `select_first` | `<CR>` | exits | Selects the first (closest) target |
+| `select_last` | (none) | exits | Selects the last (furthest) target |
+| `toggle_hint_position` | (none) | stays | Toggles hint labels between start/end of targets |
+| `toggle_direction` | `<M-d>` | re-runs | Flips search direction (forward/backward) |
+| `toggle_multi_window` | `<M-w>` | re-runs | Toggles single/multi-window target collection |
+| `expand_search_scope` | `<M-e>` | re-runs | Doubles the search scope (max_lines) |
+
+Add others as needed:
+
+```lua
+selection_keys = {
+    ["<CR>"]  = "select_first",
+    ["<S-CR>"] = "select_last",
+    ["<M-h>"] = "toggle_hint_position",
+    ["<M-d>"] = "toggle_direction",
+    ["<M-w>"] = "toggle_multi_window",
+    ["<M-e>"] = "expand_search_scope",
+}
+```
+
+### Examples
+
+```
+fa<CR>      jump to the first "a" (same as vanilla f)
+sa<CR>      jump to the first "a" match
+dw<CR>      delete to the first word target
+w<M-h>      toggle hints to end-of-word, then pick a label
+w<M-d>      flip to backward words, then pick a label
+s<M-w>      toggle multi-window search, then pick a label
+w<M-e>      double the search scope, then pick a label
+```
+
+### Handler Return Values
+
+Handlers return a value that controls the selection flow:
+
+- **`true`** — accept the selection and exit (like `select_first`, `select_last`)
+- **`false`** — stay in the selection loop and wait for the next keypress (like `toggle_hint_position`)
+- **`"rerun"`** — re-run the full pipeline with modified state, then return to selection (like `toggle_direction`, `toggle_multi_window`, `expand_search_scope`)
+
+### Disable
+
+```lua
+selection_keys = false
+```
+
+### Custom Handlers
+
+Selection handlers are registered modules, just like collectors, extractors, and actions:
+
+```lua
+require("smart-motion").selection_handlers.register("my_handler", {
+    run = function(ctx, cfg, motion_state)
+        -- Modify motion_state, re-render hints, etc.
+        -- Return true to exit selection, false to stay
+        return true
+    end,
+})
+
+-- Then reference it in config:
+selection_keys = {
+    ["<CR>"] = "select_first",
+    ["<Tab>"] = "my_handler",
+}
+```
+
+Keys are normalized via Vim's key notation, so `<CR>`, `<Tab>`, `<M-h>` all work.
+
+---
+
 ## Complete Example
 
 ```lua
@@ -522,6 +622,9 @@ See **[Advanced Features: Motion History](Advanced-Features.md#motion-history)**
 
     -- Keep history for 90 days
     history_max_age_days = 90,
+
+    -- Disable select-first-target (prefer explicit label selection)
+    -- selection_keys = false,
   },
 }
 ```

--- a/lua/smart-motion/config.lua
+++ b/lua/smart-motion/config.lua
@@ -37,6 +37,12 @@ M.defaults = {
 	search_idle_timeout_ms = 2000,
 	yank_highlight_duration = 150,
 	history_max_age_days = 30,
+	selection_keys = {
+		["<CR>"] = "select_first",
+		["<M-d>"] = "toggle_direction",
+		["<M-w>"] = "toggle_multi_window",
+		["<M-e>"] = "expand_search_scope",
+	},
 }
 
 ---@type SmartMotionConfig
@@ -212,6 +218,27 @@ function M.validate(user_config)
 	--
 	if config.history_max_age_days == nil or type(config.history_max_age_days) ~= "number" or config.history_max_age_days < 1 then
 		config.history_max_age_days = 30
+	end
+
+	--
+	-- Validate selection_keys
+	--
+	if config.selection_keys ~= false then
+		if config.selection_keys ~= nil and type(config.selection_keys) ~= "table" then
+			config.selection_keys = M.defaults.selection_keys
+		end
+
+		if type(config.selection_keys) == "table" then
+			local normalized = {}
+			for key, action in pairs(config.selection_keys) do
+				if type(key) == "string" and type(action) == "string" then
+					normalized[vim.fn.keytrans(key)] = action
+				else
+					log.warn("selection_keys: skipping invalid entry (key=" .. tostring(key) .. ", action=" .. tostring(action) .. ")")
+				end
+			end
+			config.selection_keys = normalized
+		end
 	end
 
 	M.validated = config

--- a/lua/smart-motion/core/registries.lua
+++ b/lua/smart-motion/core/registries.lua
@@ -8,6 +8,7 @@ local log = require("smart-motion.core.log")
 --- @field visualizers boolean
 --- @field actions boolean
 --- @field pipeline_wrappers boolean
+--- @field selection_handlers boolean
 --- @field motions boolean
 
 --- @type RegistryConstructors
@@ -19,6 +20,7 @@ local default_registry_constructors = {
 	visualizers = true,
 	actions = true,
 	pipeline_wrappers = true,
+	selection_handlers = true,
 	motions = true,
 }
 

--- a/lua/smart-motion/core/selection.lua
+++ b/lua/smart-motion/core/selection.lua
@@ -3,8 +3,51 @@ local highlight = require("smart-motion.core.highlight")
 local consts = require("smart-motion.consts")
 local flow_state = require("smart-motion.core.flow_state")
 local targets = require("smart-motion.core.targets")
+local exit_event = require("smart-motion.core.events.exit")
+local pipeline = require("smart-motion.core.engine.pipeline")
+local module_loader = require("smart-motion.utils.module_loader")
 
 local M = {}
+
+--- Re-runs the full pipeline after a selection handler modified motion_state.
+--- Resets state, clears highlights, runs pipeline + visualizer, then recurses to selection.
+--- Mirrors the search-mode re-run pattern in loop.lua.
+---@param ctx SmartMotionContext
+---@param cfg SmartMotionConfig
+---@param motion_state SmartMotionMotionState
+function M._rerun_pipeline(ctx, cfg, motion_state)
+	local state = require("smart-motion.core.state")
+
+	-- Reset selection state (targets, labels, counts)
+	state.reset(motion_state)
+	highlight.clear(ctx, cfg, motion_state)
+
+	-- Re-run pipeline (wrapped to catch exit events like EARLY_EXIT)
+	local exit_type = exit_event.wrap(function()
+		pipeline.run(ctx, cfg, motion_state)
+	end)
+
+	-- If pipeline threw an exit event (e.g., no targets), cancel gracefully
+	if exit_type then
+		log.debug("Pipeline re-run exited with: " .. tostring(exit_type))
+		motion_state.selected_jump_target = nil
+		return
+	end
+
+	local targets_list = motion_state.jump_targets or {}
+	if #targets_list == 0 then
+		log.debug("Pipeline re-run produced no targets")
+		motion_state.selected_jump_target = nil
+		return
+	end
+
+	-- Re-run visualizer to regenerate and render hint labels
+	local visualizer = module_loader.get_module(ctx, cfg, motion_state, "visualizer")
+	visualizer.run(ctx, cfg, motion_state)
+
+	-- Recurse back into selection
+	return M.wait_for_hint_selection(ctx, cfg, motion_state)
+end
 
 --- Waits for the user to press a hint key and handles both single and double character hints.
 ---@param ctx SmartMotionContext
@@ -47,6 +90,31 @@ function M.wait_for_hint_selection(ctx, cfg, motion_state)
 			-- Refresh the timestamp so chained presses (jjjj) keep the flow window alive.
 			flow_state.refresh_timestamp()
 			return
+		end
+	end
+
+	-- Selection action keys (e.g., <CR> = select_first, <M-h> = toggle_hint_position)
+	-- Handlers are registered in the selection_handlers registry.
+	-- Return true = accept selection and exit. Return false = stay in selection loop.
+	if cfg.selection_keys then
+		local key_name = vim.fn.keytrans(char)
+		local handler_name = cfg.selection_keys[key_name]
+		if handler_name then
+			local registries = require("smart-motion.core.registries"):get()
+			local handler = registries.selection_handlers.get_by_name(handler_name)
+			if handler then
+				local result = handler.run(ctx, cfg, motion_state)
+				log.debug("Selection handler '" .. handler_name .. "' triggered via " .. key_name)
+
+				if result == "rerun" then
+					return M._rerun_pipeline(ctx, cfg, motion_state)
+				elseif result then
+					return
+				end
+
+				-- Handler returned false: stay in selection, wait for next key
+				return M.wait_for_hint_selection(ctx, cfg, motion_state)
+			end
 		end
 	end
 

--- a/lua/smart-motion/init.lua
+++ b/lua/smart-motion/init.lua
@@ -21,6 +21,7 @@ function M.setup(user_config)
 		filters = require("smart-motion.filters"),
 		visualizers = require("smart-motion.visualizers"),
 		actions = require("smart-motion.actions"),
+		selection_handlers = require("smart-motion.selection_handlers"),
 		motions = require("smart-motion.motions"),
 	})
 
@@ -119,6 +120,13 @@ function M.setup(user_config)
 		register_many = registries.actions.register_many,
 		get_by_key = registries.actions.get_by_key,
 		get_by_name = registries.actions.get_by_name,
+	}
+
+	M.selection_handlers = {
+		register = registries.selection_handlers.register,
+		register_many = registries.selection_handlers.register_many,
+		get_by_key = registries.selection_handlers.get_by_key,
+		get_by_name = registries.selection_handlers.get_by_name,
 	}
 end
 

--- a/lua/smart-motion/presets.lua
+++ b/lua/smart-motion/presets.lua
@@ -241,32 +241,6 @@ function presets.delete(exclude)
 				},
 			},
 		},
-		dt = {
-			collector = "lines",
-			extractor = "text_search_2_char_until",
-			filter = "filter_words_on_cursor_line_after_cursor",
-			visualizer = "hint_start",
-			action = "delete",
-			map = true,
-			modes = { "n" },
-			metadata = {
-				label = "Delete Until Searched Text After Cursor",
-				description = "Deletes until the searched for text after the cursor",
-			},
-		},
-		dT = {
-			collector = "lines",
-			extractor = "text_search_2_char_until",
-			filter = "filter_words_on_cursor_line_before_cursor",
-			visualizer = "hint_start",
-			action = "delete",
-			map = true,
-			modes = { "n" },
-			metadata = {
-				label = "Delete Until Searched Text Before Cursor",
-				description = "Deletes until the searched for text before the cursor",
-			},
-		},
 		rdw = {
 			collector = "lines",
 			extractor = "words",
@@ -317,32 +291,6 @@ function presets.yank(exclude)
 				},
 			},
 		},
-		yt = {
-			collector = "lines",
-			extractor = "text_search_2_char_until",
-			filter = "filter_words_on_cursor_line_after_cursor",
-			visualizer = "hint_start",
-			action = "yank_until",
-			map = true,
-			modes = { "n" },
-			metadata = {
-				label = "Yank Until Searched Text After Cursor",
-				description = "Yank until the searched for text after the cursor",
-			},
-		},
-		yT = {
-			collector = "lines",
-			extractor = "text_search_2_char_until",
-			filter = "filter_words_on_cursor_line_before_cursor",
-			visualizer = "hint_start",
-			action = "yank_until",
-			map = true,
-			modes = { "n" },
-			metadata = {
-				label = "Yank Until Searched Text Before Cursor",
-				description = "Yank until the searched for text before the cursor",
-			},
-		},
 		ryw = {
 			collector = "lines",
 			extractor = "words",
@@ -391,32 +339,6 @@ function presets.change(exclude)
 				motion_state = {
 					allow_quick_action = true,
 				},
-			},
-		},
-		ct = {
-			collector = "lines",
-			extractor = "text_search_2_char_until",
-			filter = "filter_words_on_cursor_line_after_cursor",
-			visualizer = "hint_start",
-			action = "change_until",
-			map = true,
-			modes = { "n" },
-			metadata = {
-				label = "Change Until Searched Text After Cursor",
-				description = "Change until the searched for text after the cursor",
-			},
-		},
-		cT = {
-			collector = "lines",
-			extractor = "text_search_2_char_until",
-			filter = "filter_words_on_cursor_line_before_cursor",
-			visualizer = "hint_start",
-			action = "change_until",
-			map = true,
-			modes = { "n" },
-			metadata = {
-				label = "Change Until Searched Text Before Cursor",
-				description = "Change until the searched for text",
 			},
 		},
 	}, exclude)

--- a/lua/smart-motion/selection_handlers/init.lua
+++ b/lua/smart-motion/selection_handlers/init.lua
@@ -1,0 +1,127 @@
+local log = require("smart-motion.core.log")
+local highlight = require("smart-motion.core.highlight")
+local consts = require("smart-motion.consts")
+
+local HINT_POSITION = consts.HINT_POSITION
+local DIRECTION = consts.DIRECTION
+
+---@type SmartMotionRegistry<SmartMotionSelectionHandlerEntry>
+local selection_handlers = require("smart-motion.core.registry")("selection_handlers")
+
+--- Re-renders all assigned hint labels using the current motion_state.
+--- Follows the same clear→dim→apply→redraw pattern as highlight.filter_double_hints.
+---@param ctx SmartMotionContext
+---@param cfg SmartMotionConfig
+---@param motion_state SmartMotionMotionState
+local function rerender_hints(ctx, cfg, motion_state)
+	highlight.clear(ctx, cfg, motion_state)
+	highlight.dim_background(ctx, cfg, motion_state)
+
+	for label, entry in pairs(motion_state.assigned_hint_labels) do
+		local target = entry.target
+		if target then
+			if entry.is_single_prefix then
+				highlight.apply_single_hint_label(ctx, cfg, motion_state, target, label)
+			elseif #label == 2 then
+				highlight.apply_double_hint_label(ctx, cfg, motion_state, target, label)
+			end
+		end
+	end
+
+	vim.cmd("redraw")
+end
+
+---@type table<string, SmartMotionSelectionHandlerEntry>
+local handler_entries = {
+	select_first = {
+		run = function(ctx, cfg, motion_state)
+			-- selected_jump_target is already set to targets[1] by targets.get_targets(),
+			-- so just return true to accept the pre-set default.
+			return true
+		end,
+		metadata = {
+			label = "Select First",
+			description = "Selects the first (closest) target during label selection",
+		},
+	},
+
+	select_last = {
+		run = function(ctx, cfg, motion_state)
+			local targets = motion_state.jump_targets
+			if targets and #targets > 0 then
+				motion_state.selected_jump_target = targets[#targets]
+			end
+			return true
+		end,
+		metadata = {
+			label = "Select Last",
+			description = "Selects the last (furthest) target during label selection",
+		},
+	},
+
+	toggle_hint_position = {
+		run = function(ctx, cfg, motion_state)
+			-- Flip between start and end
+			if motion_state.hint_position == HINT_POSITION.START then
+				motion_state.hint_position = HINT_POSITION.END
+			else
+				motion_state.hint_position = HINT_POSITION.START
+			end
+
+			log.debug("Toggled hint_position to " .. motion_state.hint_position)
+			rerender_hints(ctx, cfg, motion_state)
+
+			-- Return false to stay in selection loop (wait for next keypress)
+			return false
+		end,
+		metadata = {
+			label = "Toggle Hint Position",
+			description = "Toggles hint labels between start and end of targets",
+		},
+	},
+
+	toggle_direction = {
+		run = function(ctx, cfg, motion_state)
+			if motion_state.direction == DIRECTION.AFTER_CURSOR then
+				motion_state.direction = DIRECTION.BEFORE_CURSOR
+			else
+				motion_state.direction = DIRECTION.AFTER_CURSOR
+			end
+			log.debug("Toggled direction to " .. motion_state.direction)
+			return "rerun"
+		end,
+		metadata = {
+			label = "Toggle Direction",
+			description = "Flips search direction (forward/backward) and re-runs pipeline",
+		},
+	},
+
+	toggle_multi_window = {
+		run = function(ctx, cfg, motion_state)
+			motion_state.multi_window = not motion_state.multi_window
+			log.debug("Toggled multi_window to " .. tostring(motion_state.multi_window))
+			return "rerun"
+		end,
+		metadata = {
+			label = "Toggle Multi-Window",
+			description = "Toggles between single and multi-window target collection",
+		},
+	},
+
+	expand_search_scope = {
+		run = function(ctx, cfg, motion_state)
+			local max = vim.api.nvim_buf_line_count(ctx.bufnr)
+			motion_state.max_lines = math.min(motion_state.max_lines * 2, max)
+			log.debug("Expanded search scope to " .. motion_state.max_lines .. " lines")
+			return "rerun"
+		end,
+		metadata = {
+			label = "Expand Search Scope",
+			description = "Doubles the search scope (max_lines) and re-runs pipeline",
+		},
+	},
+}
+
+selection_handlers.register_many(handler_entries)
+
+return selection_handlers

--- a/lua/smart-motion/types.lua
+++ b/lua/smart-motion/types.lua
@@ -11,6 +11,7 @@
 ---@field visualizers { register: fun(name: string, mod: SmartMotionVisualizerModuleEntry), register_many: fun(tbl: table<string, SmartMotionVisualizerModule>, opts?: { override?: boolean }) }
 ---@field actions { register: fun(name: string, mod: SmartMotionActionModuleEntry), register_many: fun(tbl: table<string, SmartMotionActionModule>, opts?: { override?: boolean }) }
 ---@field pipeline_wrappers { register: fun(name: string, mod: SmartMotionPipelineWrapperModuleEntry), register_many: fun(tbl: table<string, SmartMotionPipelineWrapperModule>, opts?: { override?: boolean }) }
+---@field selection_handlers { register: fun(name: string, mod: SmartMotionSelectionHandlerEntry), register_many: fun(tbl: table<string, SmartMotionSelectionHandlerEntry>, opts?: { override?: boolean }) }
 ---@field consts table  -- optional: you could also type consts more specifically later
 
 ---@class SmartMotionConfig
@@ -28,6 +29,7 @@
 ---@field search_idle_timeout_ms? number
 ---@field yank_highlight_duration? number
 ---@field history_max_age_days? number
+---@field selection_keys? false | table<string, string>
 
 ---@class SmartMotionPresets
 ---@field words? true | SmartMotionPresetKey.Words[]
@@ -46,9 +48,9 @@
 ---@alias SmartMotionPresetKey.Words "w" | "b" | "e" | "ge"
 ---@alias SmartMotionPresetKey.Lines "j" | "k"
 ---@alias SmartMotionPresetKey.Search "s" | "S" | "f" | "F" | "t" | "T" | "gs"
----@alias SmartMotionPresetKey.Delete "d" | "dt" | "dT" | "df" | "dF" | "rdw" | "rdl"
----@alias SmartMotionPresetKey.Yank "y" | "yt" | "yT" | "yf" | "yF" | "ryw" | "ryl"
----@alias SmartMotionPresetKey.Change "c" | "ct" | "cT" | "cf" | "cF"
+---@alias SmartMotionPresetKey.Delete "d" | "rdw" | "rdl"
+---@alias SmartMotionPresetKey.Yank "y" | "ryw" | "ryl"
+---@alias SmartMotionPresetKey.Change "c"
 ---@alias SmartMotionPresetKey.Treesitter "]]" | "[[" | "]c" | "[c" | "]b" | "[b" | "daa" | "caa" | "yaa" | "dfn" | "cfn" | "yfn" | "saa" | "gS" | "R"
 ---@alias SmartMotionPresetKey.Misc "." | "gmd" | "gmy" | "gQf" | "gQd" | "gQe" | "gQg" | "gTf" | "gTd" | "gTe" | "gTg"
 ---@alias SmartMotionPresetKey.Diagnostics "]d" | "[d" | "]e" | "[e"
@@ -187,6 +189,12 @@
   action: SmartMotionActionModule
 ): boolean?>
 
+---@alias SmartMotionSelectionHandlerEntry SmartMotionModuleEntry<fun(
+  ctx: SmartMotionContext,
+  cfg: SmartMotionConfig,
+  state: SmartMotionMotionState
+): boolean | "rerun">
+
 ---@class SmartMotionMotionEntry
 ---@field trigger_key? string
 ---@field action_key? string
@@ -209,6 +217,7 @@
   | "visualizers"
   | "actions"
   | "pipeline_wrappers"
+  | "selection_handlers"
   | "motions"
 
 ---@generic T
@@ -230,6 +239,7 @@
 ---@field visualizers SmartMotionRegistry<SmartMotionVisualizerModuleEntry>
 ---@field actions SmartMotionRegistry<SmartMotionActionModuleEntry>
 ---@field pipeline_wrappers SmartMotionRegistry<SmartMotionPipelineWrapperModuleEntry>
+---@field selection_handlers SmartMotionRegistry<SmartMotionSelectionHandlerEntry>
 ---@field motions SmartMotionMotionRegistry
 
 ---@class SmartMotionRegistryManager

--- a/tests/operators.lua
+++ b/tests/operators.lua
@@ -1,17 +1,17 @@
 -- SmartMotion Playground: Operator Motions
--- Presets: d, dt, dT, rdw, rdl, y, yt, yT, ryw, ryl, c, ct, cT, p, P
+-- Presets: d, rdw, rdl, y, ryw, ryl, c, p, P
 --          operator-pending: >w, gUw, =j, gqj, etc.
 --
 -- INSTRUCTIONS:
 --   d   → composable delete: press d, then a second motion (w/e/j/k/]]/etc.)
 --   y   → composable yank: press y, then a second motion
 --   c   → composable change: press c, then a second motion
---   dt  → delete until: type a char, delete from cursor to just before match
---   dT  → delete until backward
---   yt  → yank until: type a char, yank from cursor to just before match
---   yT  → yank until backward
---   ct  → change until: type a char, change from cursor to just before match
---   cT  → change until backward
+--   dt  → composable: d + t motion (delete until char via inference)
+--   dT  → composable: d + T motion (delete until backward via inference)
+--   yt  → composable: y + t motion (yank until char via inference)
+--   yT  → composable: y + T motion (yank until backward via inference)
+--   ct  → composable: c + t motion (change until char via inference)
+--   cT  → composable: c + T motion (change until backward via inference)
 --   rdw → remote delete word: pick a word label anywhere, delete that word
 --   rdl → remote delete line: pick a line label, delete that entire line
 --   ryw → remote yank word: pick a word label, yank it
@@ -24,6 +24,10 @@
 --   gUw → uppercase to word target
 --   =j  → auto-indent to line target
 --   gqj → format to line target
+--
+-- SELECT FIRST TARGET:
+--   Press <CR> during label selection to pick the first target.
+--   Example: dw<CR> deletes to the first word target (similar to dww but explicit)
 
 -- ── Section 1: Words to delete ────────────────────────────────
 
@@ -203,3 +207,13 @@ local mixed_case = "SoMe MiXeD cAsE tExT"
 
 -- Try: position cursor on "local poorly_indented", press =j, pick a line below
 -- Try: position cursor on "local lowercase_words", press gUw, pick a word target
+
+-- ============================================================================
+-- PIPELINE-MODIFYING HANDLERS IN OPERATOR CONTEXT
+-- ============================================================================
+--
+-- 1. `dw` → `<M-d>` → select backward word → backward word should be deleted
+-- 2. `yw` → `<M-d>` → select backward word → backward word should be yanked
+-- 3. `cw` → `<M-d>` → select backward word → backward word deleted, enter insert mode
+-- 4. `dw` → `<M-e>` → select distant word → word should be deleted
+-- 5. `dw` → `<M-w>` → should be no-op (multi-window disabled in op-pending)

--- a/tests/search.lua
+++ b/tests/search.lua
@@ -23,6 +23,11 @@
 -- MULTI-WINDOW:
 --   :vsplit tests/words_lines.lua
 --   Press s or f — labels should appear in BOTH windows
+--
+-- SELECT FIRST TARGET:
+--   During any label selection, press <CR> to select the first target.
+--   Example: fa<CR> jumps to the first "a" match (same as vanilla f behavior)
+--   Works with: s, S, f, F, t, T, and all operator compositions
 
 -- ── Section 1: Repeated patterns for search ───────────────────
 
@@ -288,3 +293,32 @@ end
 -- Fuzzy matches are sorted by score (best matches first)
 -- Word boundary matches score higher than mid-word matches
 -- Consecutive matches score higher than spread-out matches
+
+-- ============================================================================
+-- PIPELINE-MODIFYING SELECTION HANDLERS
+-- ============================================================================
+--
+-- TOGGLE DIRECTION (<M-d>):
+-- 1. Press `w` — forward word labels appear
+-- 2. Press `<M-d>` (Alt+D) — labels should flip to backward words
+-- 3. Select a label — cursor should jump backward
+-- 4. Press `s`, type a search — labels appear forward
+-- 5. Press `<M-d>` — labels should flip to backward matches
+--
+-- TOGGLE MULTI-WINDOW (<M-w>):
+-- 1. Open a second window (`:vsplit`)
+-- 2. Press `w` — labels appear in current window only
+-- 3. Press `<M-w>` (Alt+W) — labels should expand to both windows
+-- 4. Select a label in the other window — cursor should jump there
+--
+-- EXPAND SEARCH SCOPE (<M-e>):
+-- 1. Press `j` — line labels appear (limited scope)
+-- 2. Press `<M-e>` (Alt+E) — more line labels should appear (doubled scope)
+-- 3. Press `<M-e>` again — even more labels (doubled again)
+-- 4. Select a label — cursor should jump to that line
+--
+-- EDGE CASES:
+-- 1. Press `w` at end of file → `<M-d>` — should show backward words (non-empty)
+-- 2. Press `w` at start of file → `<M-d>` — no backward words, motion should cancel
+-- 3. Press `<M-e>` many times — scope should cap at buffer line count, not overflow
+-- 4. In operator-pending: `dw` → `<M-d>` → select backward — should delete backward word


### PR DESCRIPTION
## Summary
- Adds configurable `selection_keys` system for triggering actions during label selection
- Implements `selection_handlers` registry (same pattern as collectors/extractors/etc.)
- Ships 6 built-in handlers: `select_first`, `select_last`, `toggle_hint_position`, `toggle_direction`, `toggle_multi_window`, `expand_search_scope`
- Pipeline-modifying handlers return `"rerun"` to re-run the full pipeline mid-selection — change direction, toggle multi-window, or expand scope without cancelling

## Default keybindings
| Key | Handler | Behavior |
|-----|---------|----------|
| `<CR>` | `select_first` | Select first (closest) target |
| `<M-d>` | `toggle_direction` | Flip forward/backward and re-run pipeline |
| `<M-w>` | `toggle_multi_window` | Toggle single/multi-window and re-run |
| `<M-e>` | `expand_search_scope` | Double search scope and re-run |

Closes #123

## Test plan
- [ ] `fa<CR>` jumps to first `a` match (vanilla emulation)
- [ ] `dw<CR>` deletes cursor word (same as vanilla `dw`)
- [ ] `w` → `<M-d>` flips to backward words, select label jumps backward
- [ ] `w` → `<M-w>` expands to multi-window targets (with `:vsplit` open)
- [ ] `j` → `<M-e>` shows more line targets (doubled scope), press again for more
- [ ] `dw` → `<M-d>` → select backward word — deletes backward word
- [ ] Toggle direction at start of file (no backward targets) cancels gracefully
- [ ] `selection_keys = false` disables the entire feature
- [ ] Custom handler registration via `require("smart-motion").selection_handlers.register()`