### PR TITLE
feat: add toggle_hint_position to default selection_keys

### DIFF
--- a/docs/Advanced-Features.md
+++ b/docs/Advanced-Features.md
@@ -167,25 +167,26 @@ All coexist. Selection handlers are checked after the motion-key-repeat check, s
 
 ### Configuration
 
-Enabled by default with four mappings. The `selection_keys` config maps keys to registered handlers:
+Enabled by default with five mappings. The `selection_keys` config maps keys to registered handlers:
 
 ```lua
 -- Default
 selection_keys = {
     ["<CR>"]  = "select_first",
+    ["<M-h>"] = "toggle_hint_position",
     ["<M-d>"] = "toggle_direction",
     ["<M-w>"] = "toggle_multi_window",
     ["<M-e>"] = "expand_search_scope",
 }
 
--- Full example
+-- Full example (with optional extras)
 selection_keys = {
-    ["<CR>"]  = "select_first",
+    ["<CR>"]   = "select_first",
     ["<S-CR>"] = "select_last",
-    ["<M-h>"] = "toggle_hint_position",
-    ["<M-d>"] = "toggle_direction",
-    ["<M-w>"] = "toggle_multi_window",
-    ["<M-e>"] = "expand_search_scope",
+    ["<M-h>"]  = "toggle_hint_position",
+    ["<M-d>"]  = "toggle_direction",
+    ["<M-w>"]  = "toggle_multi_window",
+    ["<M-e>"]  = "expand_search_scope",
 }
 
 -- Disable

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -70,8 +70,9 @@ Complete guide to configuring SmartMotion.
 
   -- Key-action map for label selection (press key to trigger action)
   selection_keys = {
-    ["<CR>"]  = "select_first",       -- Enter selects the first target
-    ["<M-d>"] = "toggle_direction",   -- Flip search direction
+    ["<CR>"]  = "select_first",        -- Enter selects the first target
+    ["<M-h>"] = "toggle_hint_position", -- Flip hints between start/end of targets
+    ["<M-d>"] = "toggle_direction",    -- Flip search direction
     ["<M-w>"] = "toggle_multi_window", -- Toggle single/multi-window
     ["<M-e>"] = "expand_search_scope", -- Double the search scope
   },
@@ -467,6 +468,7 @@ Configure special keys that trigger actions during label selection:
 ```lua
 selection_keys = {
     ["<CR>"]  = "select_first",
+    ["<M-h>"] = "toggle_hint_position",
     ["<M-d>"] = "toggle_direction",
     ["<M-w>"] = "toggle_multi_window",
     ["<M-e>"] = "expand_search_scope",
@@ -484,13 +486,12 @@ selection_keys = {
 |---|---|---|---|
 | `select_first` | `<CR>` | exits | Selects the first (closest) target |
 | `select_last` | (none) | exits | Selects the last (furthest) target |
-| `toggle_hint_position` | (none) | stays | Toggles hint labels between start/end of targets |
+| `toggle_hint_position` | `<M-h>` | stays | Toggles hint labels between start/end of targets |
 | `toggle_direction` | `<M-d>` | re-runs | Flips search direction (forward/backward) |
 | `toggle_multi_window` | `<M-w>` | re-runs | Toggles single/multi-window target collection |
 | `expand_search_scope` | `<M-e>` | re-runs | Doubles the search scope (max_lines) |
 
-> **Tip:** `toggle_hint_position` and `select_last` are available but not mapped by default.
-> `toggle_hint_position` flips hint labels between the start and end of each target — useful when a label obscures the text you're trying to read. Add them to your config if you want them:
+> **Tip:** `select_last` is available but not mapped by default. Add it to your config if you want it:
 
 ```lua
 selection_keys = {

--- a/lua/smart-motion/config.lua
+++ b/lua/smart-motion/config.lua
@@ -39,6 +39,7 @@ M.defaults = {
 	history_max_age_days = 30,
 	selection_keys = {
 		["<CR>"] = "select_first",
+		["<M-h>"] = "toggle_hint_position",
 		["<M-d>"] = "toggle_direction",
 		["<M-w>"] = "toggle_multi_window",
 		["<M-e>"] = "expand_search_scope",


### PR DESCRIPTION
## Summary
- Adds `["<M-h>"] = "toggle_hint_position"` to the default `selection_keys` config
- Users get hint position toggling out of the box when copying the default config
- Updates docs to reflect the new default (5 mappings instead of 4)

## Test plan
- [x] `<M-h>` flips hint labels between start/end of targets during selection
- [x] Existing `<M-d>`, `<M-w>`, `<M-e>`, `<CR>` still work as before