### PR TITLE
refactor: make selection_keys opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,13 +437,26 @@ SmartMotion wouldn't exist without these plugins. See [Why SmartMotion](https://
   yank_highlight_duration = 150,     -- yank flash duration (ms)
   history_max_age_days = 30,         -- prune history entries older than this
   selection_keys = {                  -- key-action map during label selection
-    ["<CR>"]  = "select_first",      -- Enter picks the first target
-    ["<M-d>"] = "toggle_direction",  -- Flip search direction
-    ["<M-w>"] = "toggle_multi_window", -- Toggle single/multi-window
-    ["<M-e>"] = "expand_search_scope", -- Double the search scope
+    ["<CR>"] = "select_first",       -- Enter picks the first target
   },
 }
 ```
+
+### Selection Keys
+
+During label selection, special keys can trigger actions instead of picking a label. Only `<CR>` → `select_first` is enabled by default. Enable the others to modify the search mid-selection:
+
+```lua
+selection_keys = {
+    ["<CR>"]   = "select_first",         -- Enter picks the first target
+    ["<M-h>"]  = "toggle_hint_position", -- Flip hints between start/end of targets
+    ["<M-d>"]  = "toggle_direction",     -- Flip search direction (forward/backward)
+    ["<M-w>"]  = "toggle_multi_window",  -- Toggle single/multi-window
+    ["<M-e>"]  = "expand_search_scope",  -- Double the search scope
+}
+```
+
+Disable all selection keys with `selection_keys = false`. Remap to different keys by changing the key string. See [Configuration: Selection Keys](https://github.com/FluxxField/smart-motion.nvim/wiki/Configuration#selection-keys) for custom handlers.
 
 See [Configuration](https://github.com/FluxxField/smart-motion.nvim/wiki/Configuration) for the full reference.
 

--- a/docs/Advanced-Features.md
+++ b/docs/Advanced-Features.md
@@ -167,19 +167,15 @@ All coexist. Selection handlers are checked after the motion-key-repeat check, s
 
 ### Configuration
 
-Enabled by default with five mappings. The `selection_keys` config maps keys to registered handlers:
+Only `<CR>` → `select_first` is enabled by default. Enable the others by adding them to `selection_keys`:
 
 ```lua
 -- Default
 selection_keys = {
-    ["<CR>"]  = "select_first",
-    ["<M-h>"] = "toggle_hint_position",
-    ["<M-d>"] = "toggle_direction",
-    ["<M-w>"] = "toggle_multi_window",
-    ["<M-e>"] = "expand_search_scope",
+    ["<CR>"] = "select_first",
 }
 
--- Full example (with optional extras)
+-- Enable all handlers
 selection_keys = {
     ["<CR>"]   = "select_first",
     ["<S-CR>"] = "select_last",

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -70,11 +70,7 @@ Complete guide to configuring SmartMotion.
 
   -- Key-action map for label selection (press key to trigger action)
   selection_keys = {
-    ["<CR>"]  = "select_first",        -- Enter selects the first target
-    ["<M-h>"] = "toggle_hint_position", -- Flip hints between start/end of targets
-    ["<M-d>"] = "toggle_direction",    -- Flip search direction
-    ["<M-w>"] = "toggle_multi_window", -- Toggle single/multi-window
-    ["<M-e>"] = "expand_search_scope", -- Double the search scope
+    ["<CR>"] = "select_first",       -- Enter selects the first target
   },
 }
 ```
@@ -463,15 +459,11 @@ See **[Advanced Features: Motion History](Advanced-Features.md#motion-history)**
 
 ## Selection Keys
 
-Configure special keys that trigger actions during label selection:
+Configure special keys that trigger actions during label selection. Only `<CR>` → `select_first` is enabled by default:
 
 ```lua
 selection_keys = {
-    ["<CR>"]  = "select_first",
-    ["<M-h>"] = "toggle_hint_position",
-    ["<M-d>"] = "toggle_direction",
-    ["<M-w>"] = "toggle_multi_window",
-    ["<M-e>"] = "expand_search_scope",
+    ["<CR>"] = "select_first",
 }
 ```
 
@@ -482,25 +474,25 @@ selection_keys = {
 
 ### Built-in Handlers
 
-| Handler Name | Default Key | Return | Description |
+| Handler Name | Suggested Key | Return | Description |
 |---|---|---|---|
 | `select_first` | `<CR>` | exits | Selects the first (closest) target |
-| `select_last` | (none) | exits | Selects the last (furthest) target |
+| `select_last` | `<S-CR>` | exits | Selects the last (furthest) target |
 | `toggle_hint_position` | `<M-h>` | stays | Toggles hint labels between start/end of targets |
 | `toggle_direction` | `<M-d>` | re-runs | Flips search direction (forward/backward) |
 | `toggle_multi_window` | `<M-w>` | re-runs | Toggles single/multi-window target collection |
 | `expand_search_scope` | `<M-e>` | re-runs | Doubles the search scope (max_lines) |
 
-> **Tip:** `select_last` is available but not mapped by default. Add it to your config if you want it:
+Enable the ones you want by adding them to your config. Remap to any key you prefer:
 
 ```lua
 selection_keys = {
-    ["<CR>"]  = "select_first",
+    ["<CR>"]   = "select_first",
     ["<S-CR>"] = "select_last",
-    ["<M-h>"] = "toggle_hint_position",
-    ["<M-d>"] = "toggle_direction",
-    ["<M-w>"] = "toggle_multi_window",
-    ["<M-e>"] = "expand_search_scope",
+    ["<M-h>"]  = "toggle_hint_position",
+    ["<M-d>"]  = "toggle_direction",
+    ["<M-w>"]  = "toggle_multi_window",
+    ["<M-e>"]  = "expand_search_scope",
 }
 ```
 

--- a/lua/smart-motion/config.lua
+++ b/lua/smart-motion/config.lua
@@ -39,10 +39,6 @@ M.defaults = {
 	history_max_age_days = 30,
 	selection_keys = {
 		["<CR>"] = "select_first",
-		["<M-h>"] = "toggle_hint_position",
-		["<M-d>"] = "toggle_direction",
-		["<M-w>"] = "toggle_multi_window",
-		["<M-e>"] = "expand_search_scope",
 	},
 }
 


### PR DESCRIPTION
## Summary
- Only `<CR>` → `select_first` enabled by default
- All other handlers (`toggle_hint_position`, `toggle_direction`, `toggle_multi_window`, `expand_search_scope`, `select_last`) are opt-in
- README adds a "Selection Keys" callout showing the full config to copy-paste
- Docs updated: handler table uses "Suggested Key" instead of "Default Key"
- Matches the presets philosophy: everything is opt-in, users enable what they want

## Test plan
- [x] Default config only has `<CR>` = `select_first`
- [x] Adding handlers to config enables them as before
- [x] `selection_keys = false` disables all selection keys