### PR TITLE
feat: patterns collector, filetype dispatch, selection keys

### DIFF
--- a/lua/smart-motion/core/engine/filetype_dispatch.lua
+++ b/lua/smart-motion/core/engine/filetype_dispatch.lua
@@ -29,6 +29,10 @@ function M.apply(ctx, motion_state)
 
 	log.debug(string.format("filetype_dispatch: applying override for filetype '%s'", filetype))
 
+	-- Deep-copy metadata so mutations don't leak back to the registry entry
+	-- (the shallow copy in setup.run only copies top-level keys, not nested tables)
+	motion.metadata = vim.deepcopy(motion.metadata)
+
 	-- Swap pipeline module references
 	for _, key in ipairs({ "collector", "extractor", "modifier", "filter", "visualizer", "action" }) do
 		if override[key] then
@@ -38,7 +42,7 @@ function M.apply(ctx, motion_state)
 
 	-- Deep-merge motion_state overrides into motion.metadata.motion_state
 	if override.motion_state then
-		motion.metadata.motion_state = vim.tbl_deep_extend("force", ms, override.motion_state)
+		motion.metadata.motion_state = vim.tbl_deep_extend("force", motion.metadata.motion_state, override.motion_state)
 	end
 
 	-- Remove consumed overrides so they don't leak through the pipeline


### PR DESCRIPTION
## Summary

- **Patterns collector**: New vim regex-based target collector for buffers without treesitter parsers
- **Filetype dispatch middleware**: Pre-pipeline system that swaps motion components based on buffer filetype, enabling per-motion overrides without separate keymaps
- **Selection keys & pipeline-modifying handlers**: `<CR>` select-first, `<M-h>` toggle hint position, toggle direction, toggle multi-window, expand search scope — all mid-selection
- **Filetype dispatch bugfix**: Deep-copy metadata before mutation to prevent registry corruption (#133)
- **Selection keys refinements**: Opt-in by default, keytrans escaping fix, Alt-key combo support

## Test plan
- [ ] Verify filetype overrides work repeatedly (not just once) per #133
- [ ] Test patterns collector with vim regex in non-treesitter buffers
- [ ] Test selection_keys handlers (`<CR>`, `<M-h>`, toggle direction/multi-window)
- [ ] Verify existing treesitter, search, and operator motions still work
- [ ] Run all test playgrounds in `tests/`