### PR TITLE
fix: filetype dispatch persistence and t/T normal mode offset

### DIFF
--- a/lua/smart-motion/filters/init.lua
+++ b/lua/smart-motion/filters/init.lua
@@ -131,6 +131,9 @@ local filter_entries = {
 			description = "Keeps word targets only on the cursor line after the cursor position.",
 			merged = true,
 			module_names = { "filter_words", "cursor_line_only", "after_cursor" },
+			motion_state = {
+				direction = DIRECTION.AFTER_CURSOR,
+			},
 		},
 	},
 	filter_words_on_cursor_line_before_cursor = {
@@ -143,6 +146,9 @@ local filter_entries = {
 			description = "Keeps word targets only on the cursor line before the cursor position.",
 			merged = true,
 			module_names = { "filter_words", "cursor_line_only", "before_cursor" },
+			motion_state = {
+				direction = DIRECTION.BEFORE_CURSOR,
+			},
 		},
 	},
 	first_target = {


### PR DESCRIPTION
## Summary

- **Filetype dispatch regression** (#133): `vim.deepcopy` metadata before mutation so `filetype_overrides` aren't permanently deleted from the motion registry after first use
- **t/T normal mode offset** (#134): Add missing `direction` metadata to `filter_words_on_cursor_line_after_cursor` and `filter_words_on_cursor_line_before_cursor` so `jump.lua`'s till offset logic applies correctly

## Test plan
- [ ] Verify `t`/`T` motions in normal mode land one character before/after the target (not on it)
- [ ] Verify `dt`/`ct` operator-pending behavior is unchanged
- [ ] Verify filetype overrides work on repeated invocations
- [ ] Verify `;`/`,` repeat still works for `t`/`T`

Fixes #134