### PR TITLE
fix: use modified motion copy for metadata merge in setup.run

### DIFF
--- a/lua/smart-motion/core/engine/setup.lua
+++ b/lua/smart-motion/core/engine/setup.lua
@@ -29,14 +29,16 @@ function M.run(trigger_key)
 	local modules = module_loader.get_modules(ctx, cfg, motion_state)
 
 	-- The modules might have motion_state they would like to set
-	motion_state = state.merge_motion_state(motion_state, motion, modules)
+	-- Use motion_state.motion (the shallow copy, possibly modified by filetype_dispatch)
+	-- instead of the original registry entry, so overridden metadata is preserved.
+	motion_state = state.merge_motion_state(motion_state, motion_state.motion, modules)
 
 	-- Apply any per-mode motion_state override (e.g. o = { exclude_target = true })
 	-- Normalize ctx.mode to keymap-style single char: "no" -> "o", "v"/"V" -> "x", etc.
-	if motion.per_mode_motion_state then
+	if motion_state.motion.per_mode_motion_state then
 		local mode_key = ctx.mode:find("o") and "o" or ctx.mode:sub(1, 1)
-		local mode_override = motion.per_mode_motion_state[mode_key]
-			or motion.per_mode_motion_state[ctx.mode]
+		local mode_override = motion_state.motion.per_mode_motion_state[mode_key]
+			or motion_state.motion.per_mode_motion_state[ctx.mode]
 		if mode_override then
 			motion_state = vim.tbl_deep_extend("force", motion_state, mode_override)
 		end


### PR DESCRIPTION
## Summary
- `setup.run()` was passing the **original registry `motion`** to `state.merge_motion_state()` and the `per_mode_motion_state` check, instead of `motion_state.motion` (the shallow copy modified by `filetype_dispatch`)
- This meant filetype-overridden metadata (e.g. `patterns` list) was never merged into `motion_state` — the patterns collector found no patterns and threw `EARLY_EXIT`
- Switches all post-dispatch references from the original `motion` to `motion_state.motion`

## Root cause
The deep-copy fix in 590a37e correctly prevented registry mutation by deep-copying `motion.metadata` inside `filetype_dispatch.apply()`. But `setup.run()` still passed the **original** `motion` (line 14) to `merge_motion_state` and `per_mode_motion_state` — so overrides applied to `motion_state.motion` were silently ignored.

Fixes #133

## Test plan
- [ ] Trigger a filetype-overridden motion (e.g. `_y` in a `gitcommit` buffer) — should use the overridden collector/patterns
- [ ] Trigger the same motion again — should continue working (no regression from the deep-copy fix)
- [ ] Trigger the same motion in a non-overridden filetype (e.g. lua) — should use the default treesitter collector
- [ ] Verify operator motions with `per_mode_motion_state` still apply correctly