### PR TITLE
fix: yank actions restore cursor to match native Vim behavior

### DIFF
--- a/docs/API-Reference.md
+++ b/docs/API-Reference.md
@@ -189,8 +189,8 @@ require("smart-motion").map_motion("w")
 | `delete_jump` | Jump to target, then delete (key: `d`) |
 | `delete_line` | Jump to target, delete entire line (key: `D`) |
 | `yank` | Yank target text (no cursor movement) |
-| `yank_jump` | Jump to target, then yank (key: `y`) |
-| `yank_line` | Jump to target, yank entire line (key: `Y`) |
+| `yank_jump` | Jump to target, yank, restore cursor (key: `y`) |
+| `yank_line` | Jump to target, yank entire line, restore cursor (key: `Y`) |
 | `change` | Delete target text, enter insert mode |
 | `change_jump` | Jump to target, delete, enter insert (key: `c`) |
 | `change_line` | Jump to target, change entire line (key: `C`) |
@@ -199,8 +199,6 @@ require("smart-motion").map_motion("w")
 | `paste_line` | Jump to target, paste entire line |
 | `remote_delete` | Jump, delete, restore cursor |
 | `remote_delete_line` | Jump, delete line, restore cursor |
-| `remote_yank` | Jump, yank, restore cursor |
-| `remote_yank_line` | Jump, yank line, restore cursor |
 | `restore` | Restore cursor position |
 | `run_motion` | Re-run from history |
 | `textobject_select` | Set charwise visual selection spanning target range (for text objects) |

--- a/docs/Advanced-Features.md
+++ b/docs/Advanced-Features.md
@@ -572,13 +572,13 @@ Combine actions with `merge`:
 local merge = require("smart-motion.core.utils").action_utils.merge
 
 -- Jump and yank
-action = merge({ "jump", "yank" })
+action = merge({ "jump", "yank", "restore" })
 
 -- Jump, delete, center
 action = merge({ "jump", "delete", "center" })
 
--- Yank without moving (yank then restore cursor)
-action = merge({ "yank", "restore" })
+-- Yank that moves cursor to target (override default restore behavior)
+action = merge({ "jump", "yank" })
 ```
 
 Actions execute in order. This is how SmartMotion builds compound operations without defining every combination.

--- a/docs/Advanced-Recipes.md
+++ b/docs/Advanced-Recipes.md
@@ -397,13 +397,15 @@ require("smart-motion").register_motion("gy", {
 
 **How it works:** When you select a target, `merge` runs each action in order: first `jump` moves the cursor to the target, then `yank` yanks the word at the new position. Actions share the same `motion_state`, so the selected target is available to every action in the chain.
 
-### Remote Yank (Yank Without Moving)
+### Customizing Yank Behavior
+
+The default `yank_jump` already restores the cursor (matching native Vim behavior). But you can customize it — for example, if you want a yank that moves the cursor to the target instead:
 
 ```lua
-action = merge({ "yank", "restore" })
+action = merge({ "jump", "yank" })
 ```
 
-**How it works:** The `yank` action yanks text at the target, then `restore` returns the cursor to its original position. The result is a yank that does not move the cursor.
+**How it works:** By composing just `jump` and `yank` (without `restore`), you get a yank that leaves the cursor at the target. This is the power of Smart Motion's composability — you can override any preset's action chain to fit your workflow.
 
 ### Jump, Yank, and Center
 
@@ -444,7 +446,7 @@ require("smart-motion").register_motion("ry", {
   filter = "filter_visible",
   visualizer = "hint_before",
   modifier = "weight_distance",
-  action = "remote_yank",
+  action = "yank_jump",
   map = true,
   trigger_key = "ry",
   modes = { "n" },

--- a/docs/Building-Custom-Motions.md
+++ b/docs/Building-Custom-Motions.md
@@ -117,8 +117,8 @@ Each stage is optional (except collector, extractor, visualizer, action). Each s
 | `delete_jump` | Jump to target, then delete |
 | `delete_line` | Jump to target, delete entire line |
 | `yank` | Yank target text (no cursor movement) |
-| `yank_jump` | Jump to target, then yank |
-| `yank_line` | Jump to target, yank entire line |
+| `yank_jump` | Jump to target, yank, restore cursor |
+| `yank_line` | Jump to target, yank entire line, restore cursor |
 | `change` | Delete target and enter insert mode |
 | `change_jump` | Jump to target, delete, enter insert |
 | `change_line` | Jump to target, change entire line |
@@ -127,15 +127,13 @@ Each stage is optional (except collector, extractor, visualizer, action). Each s
 | `paste_line` | Jump to target, paste entire line |
 | `remote_delete` | Delete target, restore cursor (stays in place) |
 | `remote_delete_line` | Delete line, restore cursor |
-| `remote_yank` | Yank target, restore cursor |
-| `remote_yank_line` | Yank line, restore cursor |
 | `center` | Center screen on cursor |
 | `restore` | Restore cursor to original position |
 
 **Action naming pattern:**
 - `delete`/`yank`/`change`/`paste`: operate on target text without moving cursor
 - `*_jump`: jump to target first, then operate (used by composable operators like `dw`)
-- `remote_*`: jump, operate, restore cursor (cursor stays in place, for `rdw`/`ryw`)
+- `remote_*`: jump, operate, restore cursor (cursor stays in place, for `rdw`)
 - `*_line`: line-wise variants (used by double-tap: `dd`, `yy`, `cc`)
 
 ---

--- a/docs/Pipeline-Architecture.md
+++ b/docs/Pipeline-Architecture.md
@@ -512,8 +512,6 @@ end
 | `paste` | Paste at target |
 | `remote_delete` | Delete without moving cursor |
 | `remote_delete_line` | Delete line without moving |
-| `remote_yank` | Yank without moving cursor |
-| `remote_yank_line` | Yank line without moving |
 | `restore` | Restore cursor to original position |
 
 ### Action Merging

--- a/docs/Recipes.md
+++ b/docs/Recipes.md
@@ -256,7 +256,7 @@ Actions determine *what happens* when you pick a target.
 | `delete` | Deletes from cursor to the target |
 | `yank` | Yanks from cursor to the target |
 | `remote_delete` | Deletes the target word/line without moving cursor |
-| `remote_yank` | Yanks the target word/line without moving cursor |
+| `yank_jump` | Yanks the target word/line without moving cursor |
 | `merge({ "jump", "yank" })` | Runs multiple actions in sequence (e.g., jump then yank) |
 
 ### Collectors

--- a/docs/plans/2026-03-03-filetype-dispatch-design.md
+++ b/docs/plans/2026-03-03-filetype-dispatch-design.md
@@ -107,7 +107,7 @@ sm.motions.register("ry", {
   extractor = "pass_through",
   filter = "filter_visible",
   visualizer = "hint_before",
-  action = "remote_yank",
+  action = "yank_jump",
   metadata = {
     motion_state = {
       patterns = { "\\v\\f+" },

--- a/lua/smart-motion/actions/README.md
+++ b/lua/smart-motion/actions/README.md
@@ -59,7 +59,7 @@ Actions follow a naming pattern:
 | --- | --- | --- |
 | `delete`, `yank`, `change` | Operate on target text, no cursor movement | Explicit presets (`dt`) |
 | `delete_jump`, `yank_jump`, `change_jump` | Jump to target first, then operate | Composable operators (`dw`, `yw`, `cj`) |
-| `remote_delete`, `remote_yank` | Jump, operate, restore cursor | Remote presets (`rdw`, `ryw`) |
+| `remote_delete` | Jump, operate, restore cursor | Remote presets (`rdw`) |
 | `*_line` | Line-wise variant | Double-tap (`dd`, `yy`, `cc`) |
 
 The `*_jump` variants have `keys` registered in the action registry (e.g., `delete_jump` has `keys = { "d" }`). This is how the infer system resolves the correct action when composable operators look up their action by key.
@@ -72,5 +72,5 @@ The `*_jump` variants have `keys` registered in the action registry (e.g., `dele
 | Jump and delete/yank/change | `delete_jump`, `yank_jump`, `change_jump` |
 | Delete/yank/change without moving | `delete`, `yank`, `change` |
 | Paste at a target | `paste_jump`, `paste_line` |
-| Remote operations | `remote_delete`, `remote_yank` |
+| Remote operations | `remote_delete` |
 | Repeat a motion | `run_motion` |

--- a/lua/smart-motion/actions/init.lua
+++ b/lua/smart-motion/actions/init.lua
@@ -116,10 +116,11 @@ local action_entries = {
 		run = merge({
 			require("smart-motion.actions.jump"),
 			require("smart-motion.actions.yank"),
+			require("smart-motion.actions.restore"),
 		}),
 		metadata = {
-			label = "Jump and Yank",
-			description = "Jumps to the target and yanks it",
+			label = "Yank",
+			description = "Yanks the target without moving the cursor",
 		},
 	},
 	yank_line = {
@@ -127,10 +128,11 @@ local action_entries = {
 		run = merge({
 			require("smart-motion.actions.jump"),
 			require("smart-motion.actions.yank_line"),
+			require("smart-motion.actions.restore"),
 		}),
 		metadata = {
 			label = "Yank Line",
-			description = "Yanks the entire line at the target",
+			description = "Yanks the entire line at the target without moving the cursor",
 		},
 	},
 	restore = {
@@ -160,28 +162,6 @@ local action_entries = {
 		metadata = {
 			label = "Remote Delete Line",
 			description = "Deletes the line at the target without moving the cursor",
-		},
-	},
-	remote_yank = {
-		run = merge({
-			require("smart-motion.actions.jump"),
-			require("smart-motion.actions.yank"),
-			require("smart-motion.actions.restore"),
-		}),
-		metadata = {
-			label = "Remote Yank",
-			description = "Yanks the target without moving the cursor",
-		},
-	},
-	remote_yank_line = {
-		run = merge({
-			require("smart-motion.actions.jump"),
-			require("smart-motion.actions.yank_line"),
-			require("smart-motion.actions.restore"),
-		}),
-		metadata = {
-			label = "Remote Yank Line",
-			description = "Yanks the entire line at the target without moving the cursor",
 		},
 	},
 	paste = {

--- a/lua/smart-motion/actions/treesitter_select.lua
+++ b/lua/smart-motion/actions/treesitter_select.lua
@@ -101,16 +101,17 @@ end
 
 --- Cleans up state and exits incremental selection.
 local function cleanup()
+	local bufnr = M._bufnr
 	M._active = false
 	M._node_stack = {}
 	M._current_index = 0
 	M._bufnr = nil
 	M._initial_mode = nil
 	-- Clear any temporary keymaps
-	pcall(vim.keymap.del, "x", ";", { buffer = M._bufnr })
-	pcall(vim.keymap.del, "x", ",", { buffer = M._bufnr })
-	pcall(vim.keymap.del, "x", "<CR>", { buffer = M._bufnr })
-	pcall(vim.keymap.del, "x", "<Esc>", { buffer = M._bufnr })
+	pcall(vim.keymap.del, "x", ";", { buffer = bufnr })
+	pcall(vim.keymap.del, "x", ",", { buffer = bufnr })
+	pcall(vim.keymap.del, "x", "<CR>", { buffer = bufnr })
+	pcall(vim.keymap.del, "x", "<Esc>", { buffer = bufnr })
 	vim.api.nvim_echo({ { "", "" } }, false, {})
 end
 
@@ -167,7 +168,6 @@ function M.cancel()
 	if not M._active then
 		return
 	end
-	local bufnr = M._bufnr
 	cleanup()
 	-- Exit visual mode
 	vim.cmd("normal! v")

--- a/lua/smart-motion/presets.lua
+++ b/lua/smart-motion/presets.lua
@@ -297,7 +297,7 @@ function presets.yank(exclude)
 			modifier = "weight_distance",
 			filter = "filter_lines_around_cursor",
 			visualizer = "hint_start",
-			action = "remote_yank",
+			action = "yank_jump",
 			map = true,
 			modes = { "n" },
 			metadata = {
@@ -311,7 +311,7 @@ function presets.yank(exclude)
 			modifier = "weight_distance",
 			filter = "filter_lines_around_cursor",
 			visualizer = "hint_start",
-			action = "remote_yank",
+			action = "yank_jump",
 			map = true,
 			modes = { "n" },
 			metadata = {


### PR DESCRIPTION
## Summary
- Add `restore` to `yank_jump` and `yank_line` action chains (jump + yank + restore) so the cursor stays in place after yanking, matching native Vim behavior
- Remove redundant `remote_yank` and `remote_yank_line` actions (now equivalent to `yank_jump`/`yank_line`)
- Update presets and docs accordingly

Fixes #140