### PR TITLE
fix: auto_select_target not selecting the target

### DIFF
--- a/lua/smart-motion/core/engine/loop.lua
+++ b/lua/smart-motion/core/engine/loop.lua
@@ -26,6 +26,7 @@ function M.run(ctx, cfg, motion_state)
 
 		if #targets == 1 then
 			if cfg.auto_select_target then
+				motion_state.selected_jump_target = targets[1]
 				exit_event.throw(EXIT_TYPE.AUTO_SELECT)
 			else
 				exit_event.throw(EXIT_TYPE.CONTINUE_TO_SELECTION)


### PR DESCRIPTION
## Summary
- Set `motion_state.selected_jump_target = targets[1]` before throwing `AUTO_SELECT` exit event when `auto_select_target` is enabled and only one target exists
- Without this, the action handler received no target, silently doing nothing
- Matches the existing `count_select` path which correctly assigns the target before throwing

Fixes #141

## Test plan
- [ ] Set `auto_select_target = true` in config
- [ ] Trigger a motion that produces exactly one target (e.g., `w` with only one word ahead)
- [ ] Verify the action executes on that target without showing labels
- [ ] Verify normal multi-target behavior is unchanged