### PR TITLE
fix: auto-select target, module guards, config cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ SmartMotion wouldn't exist without these plugins. See [Why SmartMotion](https://
 {
   keys = "fjdksleirughtynm",        -- label characters, home row first
   flow_state_timeout_ms = 300,       -- chaining window, 0 to disable
-  disable_dim_background = false,    -- dim non-target text
+  dim_background = true,              -- dim non-target text
   auto_select_target = false,        -- auto-jump on single target
   native_search = true,              -- labels during / search
   count_behavior = "target",         -- "target" or "native" for j/k counts

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -32,8 +32,8 @@ Complete guide to configuring SmartMotion.
   -- Flow state timeout (ms): how long to stay in "flow" between motions
   flow_state_timeout_ms = 300,
 
-  -- Disable dimming of non-target text
-  disable_dim_background = false,
+  -- Dim non-target text for better label visibility
+  dim_background = true,
 
   -- Maximum motions stored in repeat history
   history_max_size = 20,
@@ -344,8 +344,8 @@ count_behavior = "native"
 Dim non-target text for better label visibility:
 
 ```lua
-disable_dim_background = false  -- dimming enabled (default)
-disable_dim_background = true   -- dimming disabled
+dim_background = true   -- dimming enabled (default)
+dim_background = false  -- dimming disabled
 ```
 
 ---

--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -236,7 +236,7 @@ require("smart-motion").setup({
     two_char_hint = { fg = "#000000", bg = "#00FF00", bold = true },
     dim = { fg = "#333333" },
   },
-  disable_dim_background = false,
+  dim_background = true,
 })
 ```
 

--- a/docs/Quick-Start.md
+++ b/docs/Quick-Start.md
@@ -178,7 +178,7 @@ opts = {
   native_search = true,
 
   -- Dim non-target text
-  disable_dim_background = false,
+  dim_background = true,
 
   -- Open folds at target position after jumping
   open_folds_on_jump = true,

--- a/lua/smart-motion/config.lua
+++ b/lua/smart-motion/config.lua
@@ -25,7 +25,7 @@ M.defaults = {
 	highlight = default_highlight_groups,
 	presets = {},
 	flow_state_timeout_ms = FLOW_STATE_TIMEOUT_MS,
-	disable_dim_background = false,
+	dim_background = true,
 	history_max_size = HISTORY_MAX_SIZE,
 	auto_select_target = false,
 	native_search = true,
@@ -141,10 +141,17 @@ function M.validate(user_config)
 	end
 
 	--
-	-- Validate disable_dim_background
+	-- Validate dim_background (supports deprecated disable_dim_background)
 	--
-	if config.disable_dim_background == nil or type(config.disable_dim_background) ~= "boolean" then
-		config.disable_dim_background = false
+	if config.disable_dim_background ~= nil then
+		log.warn("'disable_dim_background' is deprecated, use 'dim_background' instead")
+		if config.dim_background == nil or config.dim_background == M.defaults.dim_background then
+			config.dim_background = not config.disable_dim_background
+		end
+		config.disable_dim_background = nil
+	end
+	if config.dim_background == nil or type(config.dim_background) ~= "boolean" then
+		config.dim_background = true
 	end
 
 	--
@@ -159,6 +166,13 @@ function M.validate(user_config)
 	--
 	if config.auto_select_target == nil or type(config.auto_select_target) ~= "boolean" then
 		config.auto_select_target = false
+	end
+
+	--
+	-- Validate native_search
+	--
+	if config.native_search == nil or type(config.native_search) ~= "boolean" then
+		config.native_search = true
 	end
 
 	--

--- a/lua/smart-motion/core/engine/exit.lua
+++ b/lua/smart-motion/core/engine/exit.lua
@@ -20,6 +20,9 @@ function M.run(ctx, cfg, motion_state, exit_type)
 		-- Re-rendering here would use the full (unfiltered) key pool, which produces
 		-- different label assignments than the conflict-filtered labels the user already saw.
 		if vim.tbl_isempty(motion_state.assigned_hint_labels) then
+			if not modules.visualizer or not modules.visualizer.run then
+				return
+			end
 			modules.visualizer.run(ctx, cfg, motion_state)
 		end
 		selection.wait_for_hint_selection(ctx, cfg, motion_state)
@@ -28,7 +31,7 @@ function M.run(ctx, cfg, motion_state, exit_type)
 	if motion_state.selected_jump_target then
 		if ctx.mode and ctx.mode:find("o") and not motion_state.is_textobject then
 			require("smart-motion.actions.jump").run(ctx, cfg, motion_state)
-		else
+		elseif modules.action and modules.action.run then
 			modules.action.run(ctx, cfg, motion_state)
 		end
 	end

--- a/lua/smart-motion/core/engine/loop.lua
+++ b/lua/smart-motion/core/engine/loop.lua
@@ -37,7 +37,7 @@ function M.run(ctx, cfg, motion_state)
 		exit_event.throw(EXIT_TYPE.CONTINUE_TO_SELECTION)
 	end
 
-	-- Mulit-pass mode
+	-- Multi-pass mode
 	if motion_state.is_searching_mode then
 		while true do
 			local start_time = vim.fn.reltime()

--- a/lua/smart-motion/core/engine/pipeline.lua
+++ b/lua/smart-motion/core/engine/pipeline.lua
@@ -80,7 +80,7 @@ function M.run(ctx, cfg, motion_state)
 	exit.throw_if(not modifier_generator, EXIT_TYPE.EARLY_EXIT)
 
 	local filter_generator = modules.filter.run(modifier_generator)
-	exit.throw_if(not filter_generator)
+	exit.throw_if(not filter_generator, EXIT_TYPE.EARLY_EXIT)
 
 	targets.get_targets(ctx, cfg, motion_state, filter_generator)
 	state.finalize_motion_state(ctx, cfg, motion_state)

--- a/lua/smart-motion/core/highlight.lua
+++ b/lua/smart-motion/core/highlight.lua
@@ -167,8 +167,7 @@ end
 ---@param cfg SmartMotionConfig
 ---@param motion_state SmartMotionMotionState
 function M.dim_background(ctx, cfg, motion_state)
-	-- NOTE: Rename config to dim_background
-	if cfg.disable_dim_background ~= false or motion_state.dim_background == false then
+	if not cfg.dim_background or motion_state.dim_background == false then
 		return
 	end
 

--- a/lua/smart-motion/types.lua
+++ b/lua/smart-motion/types.lua
@@ -19,7 +19,7 @@
 ---@field highlight table<string, string | table>
 ---@field presets SmartMotionPresets
 ---@field flow_state_timeout_ms number
----@field disable_dim_background boolean
+---@field dim_background boolean
 ---@field native_search? boolean
 ---@field count_behavior? "target" | "native"
 ---@field open_folds_on_jump? boolean

--- a/lua/smart-motion/utils/module_loader.lua
+++ b/lua/smart-motion/utils/module_loader.lua
@@ -35,6 +35,16 @@ function M.get_modules(ctx, cfg, motion_state, keys)
 				module = registry.get_by_name("default")
 			end
 
+			if not module or not module.run then
+				log.error(
+					"SmartMotion: "
+						.. key
+						.. " '"
+						.. (motion[key] or "default")
+						.. "' not found in registry. Check your motion config for typos."
+				)
+			end
+
 			modules[key] = module
 		end
 	end

--- a/lua/smart-motion/visualizers/pass_through.lua
+++ b/lua/smart-motion/visualizers/pass_through.lua
@@ -7,6 +7,14 @@ local EXIT_TYPE = require("smart-motion.consts").EXIT_TYPE
 local M = {}
 
 function M.run(ctx, cfg, motion_state)
+	if not motion_state.selected_jump_target then
+		local targets = motion_state.jump_targets or {}
+		if #targets > 0 then
+			motion_state.selected_jump_target = targets[1]
+		else
+			exit.throw(EXIT_TYPE.EARLY_EXIT)
+		end
+	end
 	exit.throw(EXIT_TYPE.AUTO_SELECT)
 end
 


### PR DESCRIPTION
## Summary
- **auto_select_target fix**: Set `selected_jump_target` before throwing `AUTO_SELECT` when only one target exists (fixes #141)
- **Module guards**: Log clear error and exit gracefully when a module (action, visualizer, etc.) is not found in the registry instead of crashing
- **pass_through visualizer**: Guard `AUTO_SELECT` throw with explicit target check
- **pipeline.lua**: Add missing `EXIT_TYPE.EARLY_EXIT` to filter `throw_if`
- **Rename `disable_dim_background` to `dim_background`**: Removes confusing double-negative; old name still works with deprecation warning
- **Add missing `native_search` validation** in config
- **Typo fix**: "Mulit-pass" to "Multi-pass"

## Test plan
- [ ] Verify `auto_select_target = true` auto-jumps when only one target exists
- [ ] Verify referencing a non-existent action logs an error instead of crashing
- [ ] Verify `dim_background = true` (default) dims non-target text
- [ ] Verify `dim_background = false` disables dimming
- [ ] Verify `disable_dim_background = true` still works (with deprecation warning)
- [ ] Verify all standard motions (w, b, f, t, d, y, c, s) work correctly
- [ ] Verify repeat motion (`.`) works correctly