### PR TITLE
fix: skip extractor loading in infer for non-composable keys

### DIFF
--- a/lua/smart-motion/core/engine/infer.lua
+++ b/lua/smart-motion/core/engine/infer.lua
@@ -88,7 +88,14 @@ function M.run(ctx, cfg, motion_state)
 		end
 	end
 
-	local modules = module_loader.get_modules(ctx, cfg, motion_state, { "extractor", "action", "visualizer", "filter" })
+	-- Only request extractor if a composable motion populated it; otherwise the
+	-- fallback at line 103+ handles non-composable keys (dd, di, da, etc.) and
+	-- requesting it here would log a spurious "extractor 'default' not found" error.
+	local infer_keys = { "action", "visualizer", "filter" }
+	if motion_state.motion.extractor then
+		table.insert(infer_keys, 1, "extractor")
+	end
+	local modules = module_loader.get_modules(ctx, cfg, motion_state, infer_keys)
 
 	-- Merge inferred module metadata into motion_state (setup.run merged metadata for the
 	-- original motion, but infer may have overridden extractor/visualizer/filter/action)


### PR DESCRIPTION
## Summary
- Fixes remaining cases from #151 — `dd`, `di`, `da` (and `y`/`c` variants) were still producing the `extractor 'default' not found in registry` error
- `infer.run()` was always requesting the `"extractor"` module from `module_loader`, even for non-composable keys where no extractor is set
- Only request the extractor module when a composable motion has actually populated it; the existing fallback path already handles non-composable keys correctly

## Test plan
- [x] `dw`, `yw`, `cw` — composable motions work correctly
- [x] `dd`, `yy`, `cc` — native line operations, no error
- [x] `di(`, `da"`, `yi{` — native text objects, no error
- [x] Full test suite passes (0 failures)