### PR TITLE
feat: surround operations, textobject registry, and target expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A motion framework for Neovim. Enable a motion, enable an operator. They compose
       yank = true,         -- y + any motion
       change = true,       -- c + any motion
       treesitter = true,   -- ]], [[, af, if, ac, ic, aa, ia, fn, saa, gS, R
+      surround = true,     -- ds, cs, ys, gza, gzp, visual S + i(/a(/di"/dsq/dst/dsf/etc.
       diagnostics = true,  -- ]d, [d, ]e, [e
       misc = true,         -- . g. g1-g9 gp gP gA-gZ gmd gmy (repeat, history, pins, multi-cursor)
     },
@@ -63,7 +64,7 @@ presets = {
 Enable `words` and `delete` as presets. Now `dw`, `db`, `de`, `dge` all work. Enable `search` and `ds`, `dS`, `df`, `dt` work too. Enable `lines` and you get `dj`, `dk`. Every motion preset **multiplies** with every operator preset:
 
 ```
-11 composable motions  ×  5 operators  =  55+ compositions
+11 composable motions  ×  5 operators  =  55+ compositions  (+ surround operators)
          from 16 keys, zero mappings defined
 ```
 
@@ -91,6 +92,39 @@ daf   delete a function       gqaf  format a function
 yaa   yank an argument        =if   indent a function body
 cic   change inside a class   >ac   indent a class
 ```
+
+### Surround with labeled targets
+
+SmartMotion replaces nvim-surround with something better: **every pair on screen gets a label.**
+
+```
+ds(   → labels appear on every () pair → pick one → delimiters deleted
+cs(   → labels appear → pick one → delimiters highlight → type replacement
+ysaw( → word labels appear → pick one → word wrapped with ( )
+dsq   → labels on all quotes ("/'/`) → pick one → quotes deleted
+dst   → labels on all HTML/XML tags → pick one → tags removed
+dsf   → labels on all function calls → pick one → unwrapped
+cst   → labels on tags → pick one → tag name deleted → insert mode with live sync
+csf   → labels on calls → pick one → name deleted → insert mode at name position
+```
+
+`di(`, `da{`, `ci"`, `vi[` all show labels on every matching pair visible. No cursor proximity guessing — you pick exactly which pair you mean. `q` matches any quote type. `t` matches HTML/XML tags. `f` targets function calls for surround operations (while `dif`/`daf` still act on function bodies).
+
+Opening chars add padding (`ysaw(` → `( word )`), closing chars don't (`ysaw)` → `(word)`). Visual mode `S` wraps a selection. `gza` is a quick "wrap this word" shortcut.
+
+### Expand your target with `+` / `-`
+
+After picking a target, press `+` to grow the selection forward or `-` to grow backward. Dim hints show you what's expandable:
+
+```
+ysaw  [word labels] → pick "foo"
+      "foo" highlights, dim + on next word, dim - on previous
+  +   → range grows to "foo bar"
+  +   → range grows to "foo bar baz"
+  (   → wraps as ( foo bar baz )
+```
+
+No other motion plugin does this. `BS` undoes the last expansion. Any non-expansion key (like the delimiter) confirms and executes. Zero friction when you don't need it — just type the delimiter immediately.
 
 ### Modify the search mid-selection
 
@@ -181,7 +215,7 @@ Press an operator, then any motion key. Labels appear, pick a target, action run
 | Combo | What it does |
 |-------|-------------|
 | `dw`  | Labels words after cursor → pick one → delete it |
-| `ds`  | Live search → pick match → delete it |
+| `ds`  | Live search → pick match → delete it (without surround preset) |
 | `df`  | 2-char find → delete from cursor to target (inclusive) |
 | `dt`  | 2-char till → delete from cursor to just before target |
 | `dd`  | Delete current line |
@@ -288,6 +322,59 @@ Works best with [gitsigns.nvim](https://github.com/lewis6991/gitsigns.nvim). Mul
 </details>
 
 <details>
+<summary><b>Surround</b>: <code>ds</code> <code>cs</code> <code>ys</code> <code>gza</code> <code>gzp</code> <code>S</code> + pair text objects + <code>q</code> <code>t</code> <code>f</code></summary>
+
+**Pair text objects** (work with ANY operator: `di(`, `ya{`, `ci"`, `>a[`):
+
+| Key   | Mode    | Description                          |
+|-------|---------|--------------------------------------|
+| `i(`  | x, o    | Inside parentheses                   |
+| `a(`  | x, o    | Around parentheses                   |
+| `i{`  | x, o    | Inside braces                        |
+| `a{`  | x, o    | Around braces                        |
+| `i[`  | x, o    | Inside brackets                      |
+| `a[`  | x, o    | Around brackets                      |
+| `i<`  | x, o    | Inside angle brackets                |
+| `a<`  | x, o    | Around angle brackets                |
+| `i"`  | x, o    | Inside double quotes                 |
+| `a"`  | x, o    | Around double quotes                 |
+| `i'`  | x, o    | Inside single quotes                 |
+| `a'`  | x, o    | Around single quotes                 |
+| `iq`  | x, o    | Inside nearest quote (any type)      |
+| `aq`  | x, o    | Around nearest quote (any type)      |
+| `it`  | x, o    | Inside HTML/XML tag                  |
+| `at`  | x, o    | Around HTML/XML tag                  |
+
+Closing chars work too: `di)` = `di(`, `da}` = `da{`, etc.
+
+**Surround operators**:
+
+| Key   | Mode | Description                                          |
+|-------|------|------------------------------------------------------|
+| `ds(` | n    | Delete surrounding parens (leaves content)           |
+| `cs(` | n    | Change surrounding parens (prompts for replacement)  |
+| `dsq` | n    | Delete nearest surrounding quote (any type)          |
+| `csq` | n    | Change nearest quote to something else               |
+| `dst` | n    | Delete surrounding HTML/XML tag                      |
+| `cst` | n    | Change surrounding tag (in-place, live multi-cursor) |
+| `dsf` | n    | Unwrap function call: `print(x)` → `x`              |
+| `csf` | n    | Change function name (in-place insert mode)          |
+| `ys`  | n    | Add surround: `ysaw(` = wrap word with parens        |
+| `gza` | n    | Quick surround: word hints → pick → type delimiter   |
+| `gzp` | n    | Paste surround: wrap with previously yanked pair     |
+| `S`   | x    | Surround visual selection (type delimiter to wrap)   |
+
+**Padding**: opening chars add spaces (`ysaw(` → `( word )`), closing chars don't (`ysaw)` → `(word)`). Configure with `surround_pad`.
+
+Unlike native text objects, SmartMotion pair text objects label ALL matching pairs on screen. `di(` shows hints on every `()` pair visible, pick the one you want.
+
+**Special surround types**: `t` prompts for a tag name (`ysiw t` → "Tag: " → type `div` → `<div>word</div>`). `f` prompts for a function name. `q` matches all three quote types at once. `cst` and `csf` use in-place editing instead of prompts -- see below.
+
+**Target expansion**: After picking a target with `ys` or `gza`, press `+` to grow forward, `-` to grow backward, `BS` to shrink. Wrap multiple words in one go: `ysaw` → pick → `++` → `(` → `( three words here )`.
+
+</details>
+
+<details>
 <summary><b>Misc</b>: repeat, history, pins, global pins, multi-cursor</summary>
 
 | Key          | Mode | Description                                          |
@@ -369,6 +456,7 @@ With all presets enabled, SmartMotion consolidates:
 
 ```
 flash.nvim          →  search, treesitter, labels
+nvim-surround       →  ds, cs, ys, visual S + pair text objects + tags + function calls
 harpoon             →  pins (g1-g9, gp) + history (g.)
 nvim-treesitter-    →  af/if/ac/ic/aa/ia text objects
   textobjects
@@ -392,6 +480,9 @@ One plugin, one config. Your pins know about your history. Your text objects wor
 | Fuzzy search | | | | yes |
 | Treesitter navigation | | | yes | yes |
 | Treesitter text objects | | | | yes |
+| Surround (ds/cs/ys) | | | | yes |
+| Pair text objects (di(/a{) | | | | yes |
+| Target expansion (+/-) | | | | yes |
 | Composable d/y/c/p | | | partial | full |
 | Remote operations | | | yes | yes |
 | Multi-window | | via plugin | yes | yes |
@@ -436,6 +527,12 @@ SmartMotion wouldn't exist without these plugins. See [Why SmartMotion](https://
   max_pins = 9,                      -- maximum pin slots
   search_timeout_ms = 500,           -- auto-proceed after typing in search
   search_idle_timeout_ms = 2000,     -- exit search with no input
+  surround_pad = "opening",          -- "opening", "closing", or false
+  expansion_keys = {                  -- keys for target expansion (+ grows, - shrinks)
+    ["+"] = "expand_forward",
+    ["-"] = "expand_backward",
+    ["<BS>"] = "shrink",
+  },
   yank_highlight_duration = 150,     -- yank flash duration (ms)
   history_max_age_days = 30,         -- prune history entries older than this
   selection_keys = {                  -- key-action map during label selection

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -65,3 +65,15 @@
 - Jump to Git Conflicts.
 - Search & Replace with Hints.
 - History review with labels.
+
+---
+
+## Phase 7: Surround & Text Objects (v1.3.0+)
+
+### Completed
+- ✅ Textobject registry (separate from composable motions, same key can exist in both)
+- ✅ Pair text objects (`i`/`a` + delimiter: parentheses, brackets, braces, quotes, tags)
+- ✅ Surround operators (`ds`, `cs`, `ys` — delete, change, add surrounding pairs)
+- ✅ Standalone surround (`gza` add surround, `gzp` paste surround, visual `S`)
+- ✅ Pattern-based pair detection fallback (works without treesitter)
+- ✅ Configurable padding (`surround_pad`)

--- a/docs/API-Reference.md
+++ b/docs/API-Reference.md
@@ -7,6 +7,7 @@ Complete reference for SmartMotion modules and data structures.
 ## Table of Contents
 
 - [Motion Registration](#motion-registration)
+- [Textobject Registration](#textobject-registration)
 - [Built-in Modules](#built-in-modules)
 - [Motion State](#motion-state)
 - [Context Object](#context-object)
@@ -113,6 +114,124 @@ require("smart-motion").map_motion("w")
 
 ---
 
+## Textobject Registration
+
+Text objects (`i`/`a` prefix) live in a separate registry from composable motions. The same key can exist in both registries (`f` composable = 2-char find, `f` textobject = function) because they are consulted in different contexts.
+
+### register
+
+```lua
+require("smart-motion").textobjects.register(key, entry)
+```
+
+Register a single textobject.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `key` | string | Textobject key (e.g., `"("`, `"f"`, `"c"`) |
+| `entry` | table | Textobject entry |
+
+### register_many
+
+```lua
+require("smart-motion").textobjects.register_many(table)
+```
+
+Register multiple textobjects at once:
+
+```lua
+require("smart-motion").textobjects.register_many({
+  ["("] = { ... },
+  ["["] = { ... },
+  f = { ... },
+})
+```
+
+### get
+
+```lua
+require("smart-motion").textobjects.get(key)
+```
+
+Returns the textobject entry for `key`, or `nil` if not registered.
+
+### has
+
+```lua
+require("smart-motion").textobjects.has(key)
+```
+
+Returns `true` if a textobject is registered for `key`.
+
+### Entry Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `collector` | string | Yes | Collector module name |
+| `extractor` | string | Yes | Extractor module name |
+| `modifier` | string | No | Modifier module name |
+| `filter` | string | No | Filter module name |
+| `visualizer` | string | No | Visualizer module name |
+| `metadata` | table | No | Additional metadata |
+| `inside` | table | No | `motion_state` overrides merged when the `i` prefix is used |
+| `around` | table | No | `motion_state` overrides merged when the `a` prefix is used |
+| `surround` | table | No | `motion_state` overrides merged for surround operators (`ds`, `cs`) |
+| `default` | string | No | Which prefix to use when none is specified (`"inside"` or `"around"`) |
+
+The `inside`, `around`, and `surround` fields are plain `motion_state` fragments. When the user types a prefix (`i`, `a`, or a surround operator), the corresponding fragment is merged into `motion_state` before the pipeline runs.
+
+### Prefix Overrides (`_collector_override` / `_extractor_override`)
+
+A textobject's `inside`, `around`, or `surround` fragments can include `_collector_override` and `_extractor_override` fields. When present, these swap the textobject's collector and/or extractor for that prefix only. This allows a single textobject key to use completely different pipeline modules depending on whether it's accessed via `i`/`a` or via surround operators.
+
+**Example:** The `f` textobject uses `treesitter` collector for `dif`/`daf` (function bodies) but swaps to `function_calls` collector for `dsf`/`csf` (function call expressions):
+
+```lua
+f = {
+    collector = "treesitter",       -- default: function definitions
+    extractor = "pass_through",
+    -- ...
+    inside = { ts_inner_body = true },
+    around = {},
+    surround = {
+        _collector_override = "function_calls",  -- swap collector for surround
+        _extractor_override = "pairs",           -- swap extractor for surround
+        pair_scope = "surround",
+        is_surround = true,
+    },
+}
+```
+
+This pattern is useful when the same conceptual textobject key (`f` for "function") should behave differently in different contexts.
+
+### Example
+
+```lua
+-- Register a custom pair textobject
+require("smart-motion").textobjects.register("(", {
+  collector = "pairs",
+  extractor = "pairs",
+  visualizer = "hint_start",
+  inside = { pair_scope = "inside" },
+  around = { pair_scope = "around" },
+  surround = { pair_scope = "surround", is_surround = true },
+  default = "around",
+  metadata = {
+    label = "Parentheses",
+    open = "(",
+    close = ")",
+  },
+})
+
+-- Now di( deletes inside parens, da( deletes around parens,
+-- ds( deletes the surrounding parens, cs( changes the surrounding parens.
+-- All show hint labels so you can pick which pair to act on.
+```
+
+---
+
 ## Built-in Modules
 
 ### Collectors
@@ -121,6 +240,9 @@ require("smart-motion").map_motion("w")
 |------|-------------|
 | `lines` | All buffer lines |
 | `treesitter` | Syntax nodes (see Treesitter modes below) |
+| `pairs` | Matching delimiter pairs (treesitter + pattern fallback) |
+| `tags` | HTML/XML tag pairs (treesitter + pattern fallback) |
+| `function_calls` | Function call expressions (treesitter + pattern fallback) |
 | `diagnostics` | LSP diagnostics |
 | `git_hunks` | Git changed regions |
 | `quickfix` | Quickfix/location list entries |
@@ -145,6 +267,7 @@ require("smart-motion").map_motion("w")
 | `text_search_2_char_until` | Two char, exclude target (till) |
 | `live_search` | Incremental search |
 | `fuzzy_search` | Fuzzy matching |
+| `pairs` | Delimiter pair extraction (open/close ranges) |
 | `pass_through` | Collector output unchanged |
 
 ### Modifiers

--- a/docs/Advanced-Features.md
+++ b/docs/Advanced-Features.md
@@ -564,6 +564,250 @@ d[b   delete to previous block
 
 ---
 
+## Textobject System
+
+SmartMotion has a dedicated textobject registry, separate from the composable motion registry. The same key can exist in both registries because they're consulted in different contexts: `f` as a composable motion is 2-char find, while `f` as a textobject is function.
+
+### How the Registry Works
+
+Each textobject registers once with inside/around/surround overrides. These overrides are `motion_state` fragments that get merged when the textobject resolves:
+
+```lua
+-- How the "(" textobject is defined internally
+["("] = {
+    collector = "pairs",
+    extractor = "pairs",
+    inside  = { pair_scope = "inside" },
+    around  = { pair_scope = "around" },
+    surround = { pair_scope = "surround", is_surround = true },
+    default = "around",
+}
+```
+
+When you type `di(`, the system resolves `(` in the textobject registry, selects the `inside` overrides, and merges them into the motion state. The pipeline then collects all `()` pairs, extracts the content between delimiters, labels them, and the `d` operator deletes your selection.
+
+Treesitter textobjects (`f`, `c`, `a`) and pair textobjects (`(`, `[`, `{`, `<`, `"`, `'`, `` ` ``) share the same registry. Both kinds work with `i`/`a` prefixes, with any vim operator, and in visual mode.
+
+### Key Resolution (`i`/`a` Prefix)
+
+When an infer operator (`d`, `y`, `c`, `ys`, `ds`, `cs`) reads the next key, the **key resolver** buffers input and resolves it in priority order:
+
+1. **Pre-set `textobject_key`**: Some operators (like `ds` and `cs`) pre-set which textobject mode to use (`surround`). The next character is looked up directly in the textobject registry.
+2. **`i`/`a` prefix**: If the first character is `i` or `a`, the resolver reads the next character and checks the textobject registry. `di(` resolves as delete + inside + `(` textobject.
+3. **Composable motion**: Otherwise, multi-char resolution with `timeoutlen` handles composable motions (`dw`, `dfn`, etc.).
+4. **Fallback**: If nothing matches, the key sequence is fed back to vim for native handling (`diW`, `da"` with no registered textobject, etc.).
+
+This means `i` and `a` are **not consumed** when they don't match a registered textobject. Type `diG` and the `i` prefix reads `G`, finds no textobject, and the full sequence `iG` feeds back to vim as a native text object.
+
+### Dual-Level `i`/`a` Handling
+
+The `i`/`a` prefix is handled at two levels:
+
+- **In infer operators** (`d`, `y`, `c`): The key resolver detects the prefix and routes to the textobject registry. This is how `dif` (delete inside function) works.
+- **In native vim operators and visual mode**: The `textobject_keymaps` module registers `i` and `a` in `x` and `o` modes. When you type `vif` or `=af`, the keymap reads the next character, checks the textobject registry, and either runs the SmartMotion pipeline or falls back to native vim.
+
+Both paths converge on the same textobject pipeline. Labels appear, you pick a target, and the operator applies.
+
+---
+
+## Surround Operations
+
+The `surround` preset provides `ds`, `cs`, `ys`, `gza`, `gzp`, and visual `S`.
+
+### Delete Surround (`ds`)
+
+```
+ds(   labels all () pairs → pick one → delimiters removed
+ds"   labels all "" pairs → pick one → quotes removed
+ds{   labels all {} pairs → pick one → braces removed
+```
+
+`ds` pre-sets `textobject_key = "surround"` so the next character is looked up directly in the textobject registry. No `i`/`a` prefix is needed. The textobject's `surround` overrides activate, the pipeline collects all matching pairs, and you pick which one to act on.
+
+### Change Surround (`cs`)
+
+```
+cs(   labels all () pairs → pick one → delimiters highlight → type replacement char
+cs"   labels all "" pairs → pick one → quotes highlight → type replacement char
+```
+
+After you pick a target, SmartMotion **highlights the selected delimiters** so you can see exactly what you're changing. Then it prompts for a replacement character. Opening chars (like `(`) add padding (`( word )`), closing chars (like `)`) don't (`(word)`), controlled by the `surround_pad` config.
+
+### Add Surround (`ys`)
+
+`ys` is an infer operator that composes with both textobjects and composable motions:
+
+```
+ysaw   → around + w composable → labels on words → pick target → type delimiter
+ysaf   → around + f textobject → labels on functions → pick target → type delimiter
+ysiw   → inside + w composable → labels on words → pick target → type delimiter
+ysif   → inside + f textobject → labels on functions → pick target → type delimiter
+```
+
+After you pick a target, SmartMotion **highlights the target region** so you can see what will be wrapped. Then it prompts for a delimiter character.
+
+The `ys` operator opts into `ia_resolve_composable`, which means when `i`/`a` is followed by a character that isn't a registered textobject, the resolver tries composable motion lookup instead of falling back to vim. This is how `ysaw` works: `a` reads `w`, `w` isn't a textobject, so the resolver looks up `w` as a composable motion and carries the `around` scope through.
+
+### Standalone Add (`gza`)
+
+```
+gza   → labels on words → pick target → type delimiter → target wrapped
+```
+
+Skips the `i`/`a` prefix entirely. Labels appear on all words immediately.
+
+### Visual Surround (`S`)
+
+In visual mode, `S` wraps the current selection:
+
+```
+(visually select text) S(   → selection highlighted → type delimiter → text wrapped
+```
+
+The visual selection is highlighted with `SmartMotionSelected` while you choose a delimiter.
+
+### Surround Paste (`gzp`)
+
+Re-applies the last yanked delimiter pair:
+
+```
+ysi(   → yank surround stores "()" in register
+gzp    → labels on words → pick target → target wrapped with ()
+```
+
+### Quote Alias (`q`)
+
+The `q` key matches any quote type (`"`, `'`, `` ` ``) simultaneously:
+
+```
+dsq   → labels appear on ALL quote pairs (double, single, backtick) → pick one → removed
+csq   → labels on all quotes → pick one → type replacement delimiter
+diq   → delete inside nearest quote (any type)
+vaq   → visually select around nearest quote
+```
+
+Internally, `q` reuses the `pairs` collector with `pair_chars` set to all three quote types. Labels appear on every quote pair on screen regardless of type, so you can target a double-quoted string and a backtick-quoted string in the same operation.
+
+### HTML/XML Tags (`t`)
+
+The `t` textobject targets HTML/XML tag pairs:
+
+```
+dst   → labels on all tag pairs → pick one → tags removed: <div>foo</div> → foo
+dit   → delete inside tag: <div>hello world</div> → <div></div>
+vat   → visually select around tag (including delimiters)
+ysiw t → word labels → pick one → prompts "Tag:" → type "span" → <span>word</span>
+Visual S then type t → prompts "Tag:" → wraps selection with tag
+```
+
+Tag detection uses a `tags` collector that tries treesitter first (for HTML, JSX, TSX files where tag nodes exist in the tree) and falls back to pattern-based scanning for other file types. The pattern fallback matches `<tagname ...>...</tagname>` structures.
+
+When used as a surround delimiter in `ys`/`S`, typing `t` triggers a `vim.fn.input` prompt for the tag name.
+
+**`cst` — Live multi-cursor tag rename:**
+
+`cst` does not use a command-line prompt. Instead, it uses in-place editing with real-time synchronization between opening and closing tags:
+
+```
+cst → labels on all tag pairs → pick one
+    → tag name deleted from BOTH opening and closing tags simultaneously
+    → cursor enters insert mode in the opening tag, right after <
+    → as you type, the closing tag mirrors your input in real-time
+    → the closing tag name highlights in blue as it syncs
+    → press ESC when done — both tags have the new name
+```
+
+Example: `cst` on `<div>foo</div>` → `<|>foo</>` → type `span` → both update live → `<span>foo</span>`
+
+This is a unique feature — no other surround plugin does real-time multi-cursor tag rename. Other plugins (like nvim-surround) use a command-line prompt to read the new tag name, then apply it. SmartMotion lets you see both tags update as you type, directly in the buffer.
+
+### Function Calls (`f` surround)
+
+The `f` textobject has dual behavior depending on the prefix:
+
+```
+dif   → delete inside function BODY (treesitter function definition) — unchanged
+daf   → delete around function BODY (treesitter function definition) — unchanged
+dsf   → unwrap function CALL: print(foo, bar) → foo, bar
+csf   → change function name (in-place insert mode, see below)
+```
+
+This is achieved through the `_collector_override` / `_extractor_override` pattern. The `f` textobject is registered once, but its `surround` overrides swap the collector from `treesitter` (for inside/around) to `function_calls` (for surround). The `function_calls` collector finds `call_expression` nodes via treesitter with a pattern-based fallback.
+
+`dsf` specifically targets the function *call* (name + parentheses), not the function *definition*. This means on `print(foo, bar)`, `dsf` removes the `print(` and `)`, leaving `foo, bar`.
+
+**`csf` — In-place function name change:**
+
+`csf` does not use a command-line prompt. Instead, it deletes the function name and enters insert mode at that position:
+
+```
+csf → labels on all function calls → pick one
+    → function name is deleted, cursor enters insert mode at the name position
+    → type the new name directly in-place
+    → press ESC when done
+```
+
+Example: `csf` on `console.log(x)` → cursor at `|(x)` in insert mode → type `warn` → `warn(x)`
+
+This behaves like `ci` — delete the target and enter insert mode for you to type the replacement. It's faster than a prompt because you see the result in the buffer as you type.
+
+### Pattern-Based Pair Detection
+
+The pairs collector uses a two-tier detection strategy:
+
+1. **Treesitter first**: Walks the syntax tree looking for nodes whose first and last children match the delimiter characters. This gives structurally correct results.
+2. **Pattern fallback**: If the treesitter parse tree has errors (common while actively editing), falls back to a stack-based pattern scanner. Asymmetric pairs (`()`, `[]`, `{}`, `<>`) use stack matching. Symmetric pairs (`""`, `''`, `` `` ``) pair adjacent occurrences on the same line.
+
+This means pair textobjects work reliably even in broken syntax, unparsed file types, or mid-edit states where treesitter can't produce a clean tree.
+
+---
+
+## Target Expansion
+
+Target expansion lets you grow or shrink a selection after picking a target, before the surround action executes. It hooks into the exit flow between target selection and action execution.
+
+### How It Works
+
+1. Trigger a surround motion (`ys` or `gza`)
+2. Pick a target from the labeled hints
+3. **Expansion phase begins**: the selected target highlights, and dim `+`/`-` hints appear on adjacent targets
+4. Press `+` to expand forward (include the next target), `-` to expand backward (include the previous target), or `<BS>` to shrink (undo the last expansion)
+5. The range highlight grows or shrinks as you press expansion keys
+6. Press any other key (the delimiter character) to confirm and execute the surround action
+
+### Visual UX
+
+During expansion, three visual cues help you see what's happening:
+
+- **Selected target**: highlighted with `SmartMotionSelected` so you can see the current range
+- **Dim `+`/`-` hints**: appear on the adjacent targets in the forward and backward directions, showing what would be included next
+- **Range highlight**: updates in real time as you expand or shrink, covering the full span from the first to last included target
+
+### Where It Hooks In
+
+Expansion sits between selection and action in the pipeline exit flow:
+
+```
+... → Visualizer → Selection → [Expansion] → Action
+```
+
+After the user picks a target (Selection), the expansion phase optionally activates. Once the user presses a non-expansion key, that key is captured as the delimiter and passed to the surround action.
+
+### Which Motions Support It
+
+Expansion only activates on motions with `expansion_enabled = true` in their motion state. Currently this includes:
+
+- **`ys`** (add surround via composable motion/textobject)
+- **`gza`** (quick surround add)
+
+Other surround operations (`ds`, `cs`, `gzp`, visual `S`) do not use expansion because the target scope is already determined by the delimiter pair or visual selection.
+
+### Configuration
+
+The expansion keys are configurable. See **[Configuration: Expansion Keys](Configuration.md#expansion-keys)** for details on remapping or disabling.
+
+---
+
 ## Action Composition
 
 Combine actions with `merge`:

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -68,9 +68,19 @@ Complete guide to configuring SmartMotion.
   -- Prune history entries older than this many days
   history_max_age_days = 30,
 
+  -- Controls spacing when adding or changing surrounds
+  surround_pad = "opening",
+
   -- Key-action map for label selection (press key to trigger action)
   selection_keys = {
     ["<CR>"] = "select_first",       -- Enter selects the first target
+  },
+
+  -- Keys for target expansion during surround (ys, gza)
+  expansion_keys = {
+    ["+"] = "expand_forward",        -- Grow selection forward
+    ["-"] = "expand_backward",       -- Grow selection backward
+    ["<BS>"] = "shrink",             -- Undo last expansion
   },
 }
 ```
@@ -543,6 +553,101 @@ selection_keys = {
 ```
 
 Keys are normalized via Vim's key notation, so `<CR>`, `<Tab>`, `<M-h>` all work.
+
+---
+
+## Expansion Keys
+
+Configure the keys used for target expansion during surround operations (`ys`, `gza`). After picking a target, these keys let you grow or shrink the selection before typing the delimiter:
+
+```lua
+expansion_keys = {
+    ["+"] = "expand_forward",
+    ["-"] = "expand_backward",
+    ["<BS>"] = "shrink",
+}
+```
+
+**Default keys:**
+
+| Key | Action | Description |
+|-----|--------|-------------|
+| `+` | `expand_forward` | Grow selection to include the next adjacent target |
+| `-` | `expand_backward` | Grow selection to include the previous adjacent target |
+| `<BS>` | `shrink` | Undo the last expansion step |
+
+Any key that isn't an expansion key confirms the selection and is treated as the delimiter character.
+
+**Disable expansion entirely:**
+
+```lua
+expansion_keys = false
+```
+
+**Remap to different keys:**
+
+```lua
+expansion_keys = {
+    ["<Tab>"] = "expand_forward",
+    ["<S-Tab>"] = "expand_backward",
+    ["<BS>"] = "shrink",
+}
+```
+
+Expansion only activates on motions that have `expansion_enabled = true` in their motion state. Currently this includes `ys` and `gza` from the surround preset.
+
+---
+
+## Surround Padding
+
+Control whether surrounding pairs add inner padding (spaces inside the delimiters):
+
+```lua
+surround_pad = "opening"  -- default
+```
+
+**Setting:** `surround_pad`
+
+**Type:** `"opening"` | `"closing"` | `false`
+
+**Default:** `"opening"`
+
+**Behavior by value:**
+
+- **`"opening"` (default):** Opening characters (`(`, `{`, `[`, `<`) add inner padding. Closing characters do not.
+  - `ysaw(` → `( word )`
+  - `ysaw)` → `(word)`
+
+- **`"closing"`:** Closing characters add padding instead. Opening characters do not.
+  - `ysaw)` → `( word )`
+  - `ysaw(` → `(word)`
+
+- **`false`:** No padding ever. Both opening and closing produce tight wrapping.
+  - `ysaw(` → `(word)`
+  - `ysaw)` → `(word)`
+
+Quotes (`"`, `'`, `` ` ``) never pad regardless of setting.
+
+Tags (`t`) and function calls (`f`) never pad — they use their own formatting (`<tag>content</tag>`, `name(content)`).
+
+```lua
+{
+  surround_pad = "opening",  -- default: ( pads, ) doesn't
+  -- surround_pad = "closing", -- flip: ) pads, ( doesn't
+  -- surround_pad = false,     -- no padding ever
+}
+```
+
+The surround preset includes `q` (any-quote alias), `t` (HTML/XML tags), and `f` (function call surround) by default. These can be disabled individually:
+
+```lua
+presets = {
+  surround = {
+    -- disable tag or function call surround if not needed
+    -- (textobject keys are disabled via the treesitter preset for f)
+  },
+}
+```
 
 ---
 

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -12,13 +12,13 @@ Other motion plugins give you a fixed set of features. SmartMotion gives you a *
 Collector → Extractor → Modifier → Filter → Visualizer → Selection → Action
 ```
 
-This isn't just a plugin. It's a **framework**. The 140+ built-in keybindings? They're all built on the same system you can use to create your own.
+This isn't just a plugin. It's a **framework**. The 160+ built-in keybindings? They're all built on the same system you can use to create your own.
 
 ---
 
 ## One Plugin to Replace Them All
 
-SmartMotion unifies the best ideas from hop, leap, flash, and mini.jump, then goes further:
+SmartMotion unifies the best ideas from hop, leap, flash, mini.jump, and nvim-surround, then goes further:
 
 | Feature | hop | leap | flash | SmartMotion |
 |---------|-----|------|-------|-------------|
@@ -34,6 +34,8 @@ SmartMotion unifies the best ideas from hop, leap, flash, and mini.jump, then go
 | Multi-cursor selection | | | | ✓ |
 | Argument swap | | | | ✓ |
 | Visual range selection | | | | ✓ |
+| Surround (add/delete/change + tags/functions/quotes) | | | | ✓ |
+| Target expansion (+/-) | | | | ✓ |
 | **Extensible pipeline** | | | | ✓ |
 | **Build your own motions** | | | | ✓ |
 
@@ -58,6 +60,19 @@ Works with `y` (yank), `c` (change), `p` (paste). Chain any operator with any mo
 - `cfn` - change function name (instant rename via multi-char infer)
 - `yaa` - yank around argument (with separator awareness)
 - `saa` - swap two arguments
+
+### Surround Operations
+- `ds(` - delete surrounding parentheses
+- `cs("` - change surrounding parens to quotes
+- `dsq` - delete nearest surrounding quote (any type: `"`, `'`, `` ` ``)
+- `dst` - delete surrounding HTML/XML tag
+- `dsf` - unwrap function call: `print(x)` → `x`
+- `cst` - change surrounding tag (in-place insert mode with real-time sync to closing tag)
+- `csf` - change function name (in-place insert mode at name position)
+- `ysiw(` - surround a word with parentheses
+- `ysiw t` - surround a word with an HTML tag (prompts for tag name)
+- `S` (visual) - surround the selection with a delimiter
+- **Target expansion**: pick a word, press `+`/`-` to grow the selection, then type the delimiter
 
 ### Search That Actually Works
 - `s` - live search with labels as you type
@@ -90,13 +105,14 @@ Search, treesitter, and diagnostic motions show labels across **all visible spli
       git = true,          -- ]g, [g
       quickfix = true,     -- ]q, [q, ]l, [l
       marks = true,        -- g', gm
+      surround = true,     -- ds, cs, ys, gza, gzp, S + pair text objects + q/t/f
       misc = true,         -- . g. g1-g9 gp gP gA-gZ gmd gmy (repeat, history, pins, multi-cursor)
     },
   },
 }
 ```
 
-That's it. You now have 140+ motions that work together seamlessly.
+That's it. You now have 160+ motions that work together seamlessly.
 
 ---
 
@@ -159,7 +175,7 @@ The possibilities are endless because **you control every stage**.
 - **[Migration Guide](Migration.md)**: Coming from flash, leap, hop, or mini.jump
 
 ### Using SmartMotion
-- **[Presets Guide](Presets.md)**: All 13 presets and 140+ keybindings
+- **[Presets Guide](Presets.md)**: All 14 presets and 160+ keybindings
 - **[Advanced Features](Advanced-Features.md)**: Flow state, multi-window, operator-pending mode
 
 ### Customizing

--- a/docs/Migration.md
+++ b/docs/Migration.md
@@ -159,7 +159,7 @@ Start without operators (`delete`, `yank`, `change`) if you want to ease in. Add
 
 **Scope.** mini.jump enhances native f/F/t/T. mini.jump2d adds label jumping. SmartMotion replaces both and adds treesitter, operators, text objects, history, and more.
 
-**Ecosystem.** If you use mini.ai for text objects, SmartMotion's `af`/`if`/`ac`/`ic`/`aa`/`ia` can replace it. If you use mini.surround, that's orthogonal and works fine alongside SmartMotion.
+**Ecosystem.** If you use mini.ai for text objects, SmartMotion's `af`/`if`/`ac`/`ic`/`aa`/`ia` can replace it. If you use mini.surround, SmartMotion's `surround = true` preset provides `ds`, `cs`, `ys`, and visual `S` with hint labels on all matching pairs.
 
 ### Recommended Config for mini.jump Users
 
@@ -172,6 +172,54 @@ presets = {
   misc = true,
 }
 ```
+
+---
+
+## From nvim-surround
+
+### Keybinding Map
+
+| nvim-surround | SmartMotion | Notes |
+|---------------|-------------|-------|
+| `ds)` (delete surround) | `ds)` | Same key sequence. SmartMotion shows hint labels on all matching pairs so you pick which one. |
+| `cs)]` (change surround) | `cs)` then type `]` | SmartMotion splits into two steps: pick the pair, then type the replacement. |
+| `dst` (delete tag) | `dst` | Same key sequence. SmartMotion labels all tag pairs on screen. |
+| `cst` (change tag) | `cst` | Pick the tag → name deleted → insert mode with live sync to closing tag. |
+| `dsf` (unwrap function) | `dsf` | Same key sequence. Labels all function calls on screen. |
+| `csf` (change function) | `csf` | Pick the call → name deleted → insert mode at name position. |
+| `ysiw)` (add surround) | `ysaw)` | SmartMotion shows word hints so you pick which target to wrap. |
+| `ysiw t` + tag name | `ysiw t` + tag name | Same flow. Prompts for tag name after typing `t`. |
+| `S` in visual | `S` in visual | Same key. Select text, press `S`, type the delimiter. |
+
+### What's Different
+
+**Hint labels on everything.** nvim-surround acts on the nearest pair. SmartMotion shows hint labels on ALL matching pairs in the viewport and lets you pick which one. No more counting or navigating to get the right pair.
+
+**Two-step change.** nvim-surround's `cs)]` is a single key sequence. SmartMotion's `cs)` shows labeled pairs, you pick one, then type the replacement character. Two steps, but you can target any pair on screen.
+
+**Add surround uses motions.** nvim-surround's `ys{motion}{char}` uses native vim motions. SmartMotion's `ys` reads `i`/`a` prefix + textobject key, shows hint labels, and wraps the selected target. For example, `ysaw)` shows word targets and wraps the one you pick in parentheses.
+
+**Standalone operations.** SmartMotion adds `gza` (add surround to a word target), `gzp` (paste previously yanked pair around a target), and visual `S`. These don't have direct nvim-surround equivalents.
+
+**Tags and function calls.** `dst` and `dsf` work the same way as nvim-surround (with added label-based target picking). However, `cst` and `csf` work differently: nvim-surround uses a command-line prompt to read the new name, while SmartMotion deletes the name and enters insert mode in-place. For `cst`, as you type in the opening tag, the closing tag mirrors your input in real-time (multi-cursor style). For `csf`, the function name is deleted and you type the replacement directly at the name position. SmartMotion also adds `dsq`/`csq` for targeting any quote type (`"`, `'`, `` ` ``) without specifying which one.
+
+**Configurable padding.** SmartMotion's `surround_pad` option controls whether added pairs include inner spaces (e.g., `( foo )` vs `(foo)`).
+
+### Recommended Config for nvim-surround Users
+
+```lua
+presets = {
+  words = true,
+  search = true,
+  delete = true,
+  yank = true,
+  change = true,
+  treesitter = true,
+  surround = true,
+}
+```
+
+This gives you all surround operations plus composable operators and treesitter text objects.
 
 ---
 

--- a/docs/Presets.md
+++ b/docs/Presets.md
@@ -1,6 +1,6 @@
 # Presets Guide
 
-SmartMotion ships with **13 presets** containing **140+ keybindings**. Each preset is a logical group of related motions. Enable what you need, disable what you don't.
+SmartMotion ships with **14 presets** containing **160+ keybindings**. Each preset is a logical group of related motions. Enable what you need, disable what you don't.
 
 > **Every preset can be customized.** Want to make `f` single-char? Words bidirectional? Search line-constrained? See the [Recipes](Recipes.md) guide for practical examples.
 
@@ -22,6 +22,7 @@ SmartMotion ships with **13 presets** containing **140+ keybindings**. Each pres
 | `git` | `]g` `[g` | Git hunk navigation |
 | `quickfix` | `]q` `[q` `]l` `[l` | Quickfix/location list |
 | `marks` | `g'` `gm` | Mark navigation and setting |
+| `surround` | `i(`/`a(` `i{`/`a{` `i[`/`a[` `i<`/`a<` `i"`/`a"` `i'`/`a'` `` i` ``/`` a` `` `iq`/`aq` `it`/`at` `ds` `cs` `ys` `gza` `gzp` `S` | Pair text objects, tags, quotes, function calls, and surround operators |
 | `misc` | `.` `g.` `g0` `g1`-`g9` `gp` `gp1`-`gp9` `gP` `gA`-`gZ` `gmd` `gmy` | Repeat, history, pins, global pins, and multi-cursor |
 
 ---
@@ -385,6 +386,247 @@ Press gm → labels appear on words → select target → type 'a' → mark 'a' 
 
 ---
 
+## surround
+
+Pair text objects and surround operators. Adds labeled delimiter navigation that works with any vim operator, plus dedicated surround add/delete/change commands.
+
+### Pair Text Objects
+
+Unlike native vim text objects that act on the nearest pair, SmartMotion labels **all** matching pairs on screen and lets you pick which one.
+
+| Key | Modes | What it does |
+|-----|-------|--------------|
+| `i(`, `i)` | x, o | **Inside parentheses**: select content between `()` |
+| `a(`, `a)` | x, o | **Around parentheses**: select `()` including delimiters |
+| `i{`, `i}` | x, o | **Inside braces**: select content between `{}` |
+| `a{`, `a}` | x, o | **Around braces**: select `{}` including delimiters |
+| `i[`, `i]` | x, o | **Inside brackets**: select content between `[]` |
+| `a[`, `a]` | x, o | **Around brackets**: select `[]` including delimiters |
+| `i<`, `i>` | x, o | **Inside angle brackets**: select content between `<>` |
+| `a<`, `a>` | x, o | **Around angle brackets**: select `<>` including delimiters |
+| `i"` | x, o | **Inside double quotes**: select content between `""` |
+| `a"` | x, o | **Around double quotes**: select `""` including delimiters |
+| `i'` | x, o | **Inside single quotes**: select content between `''` |
+| `a'` | x, o | **Around single quotes**: select `''` including delimiters |
+| `` i` `` | x, o | **Inside backticks**: select content between `` `` `` |
+| `` a` `` | x, o | **Around backticks**: select `` `` `` including delimiters |
+| `iq` | x, o | **Inside nearest quote**: matches `"`, `'`, or `` ` `` |
+| `aq` | x, o | **Around nearest quote**: matches `"`, `'`, or `` ` `` |
+| `it` | x, o | **Inside tag**: select content between HTML/XML tags |
+| `at` | x, o | **Around tag**: select entire tag pair including delimiters |
+
+```
+In: foo(bar(baz), qux(123))
+
+Press di( → labels appear on ALL () pairs → select one → content inside that pair deleted
+Press va{ → labels appear on ALL {} pairs → select one → entire pair visually selected
+```
+
+**Works with any operator** — no explicit mappings needed:
+```
+di(    delete inside parens
+ya{    yank around braces
+ci"    change inside double quotes
+>a[    indent around brackets
+gqa(   format around parens
+=i{    auto-indent inside braces
+```
+
+**Key resolution:** The `i`/`a` prefix triggers a textobject lookup. If the next character is a registered text object key (like `(`, `{`, `"`, or treesitter keys like `f`, `c`, `a`), SmartMotion handles it. Unregistered keys (like `w` in `diw`) fall back to native vim.
+
+### Surround Operators
+
+| Key | Modes | What it does |
+|-----|-------|--------------|
+| `ds` | n | **Delete surround**: type pair char, labels appear on all matching pairs, pick one, delimiters removed |
+| `cs` | n | **Change surround**: type pair char, labels appear, pick pair, delimiters highlight in blue, type replacement char |
+| `dsq` | n | **Delete nearest quote**: labels all `"`, `'`, `` ` `` pairs, pick one, quotes removed |
+| `csq` | n | **Change nearest quote**: labels all quotes, pick one, type replacement char |
+| `dst` | n | **Delete surrounding tag**: `<div>foo</div>` → `foo` |
+| `cst` | n | **Change surrounding tag**: pick tag → name deleted → insert mode with real-time sync to closing tag |
+| `dsf` | n | **Unwrap function call**: `print(foo, bar)` → `foo, bar` |
+| `csf` | n | **Change function name**: pick call → name deleted → insert mode at name position |
+| `ys` | n | **Add surround**: composable — `ys` + `i`/`a` prefix + motion + delimiter char |
+| `gza` | n | **Quick surround add**: shows keyword-only word hints, pick target, type delimiter to wrap |
+| `gzp` | n | **Paste surround**: wrap target with previously yanked delimiter pair (stored from `ds`) |
+| `S` | x | **Visual surround**: select text, press `S`, type delimiter to wrap selection |
+
+### Delete Surround (`ds`)
+
+```
+In: foo(bar, baz)
+
+Press ds( → labels appear on all () pairs → press label → parens removed → foo bar, baz
+Press ds" → labels appear on all "" pairs → press label → quotes removed
+```
+
+Works with all pair types: `()`, `{}`, `[]`, `<>`, `""`, `''`, `` `` ``.
+
+**Special types:**
+
+```
+Press dsq → labels appear on ALL quote pairs (", ', `) → press label → quotes removed
+Press dst → labels appear on ALL HTML/XML tag pairs → press label → tags removed, content kept
+Press dsf → labels appear on ALL function calls → press label → unwrapped: print(foo) → foo
+```
+
+`q` searches all three quote types simultaneously — no need to remember which kind of quote you're targeting. `t` uses treesitter for HTML/JSX/TSX files with a pattern-based fallback for others. `f` targets function call expressions (name + parens), not function definitions.
+
+### Change Surround (`cs`)
+
+```
+In: foo(bar, baz)
+
+Press cs( → labels appear on () pairs → press label → parens highlight blue → type [ → foo[bar, baz]
+Press cs( → pick pair → type ( → foo( bar, baz )  (opening char adds padding)
+```
+
+**Padding convention:** Opening chars (`(`, `{`, `[`, `<`) add padding around content. Closing chars (`)`, `}`, `]`, `>`) don't. Quotes never pad. Configurable via `surround_pad`.
+
+**Special types:**
+
+```
+Press csq → labels on all quotes → pick one → quotes highlight → type replacement char
+```
+
+**`cst` — In-place tag rename with live sync:**
+
+```
+Press cst → labels on all tags → pick one → tag name deleted from BOTH opening and closing tags
+  → cursor enters insert mode in the opening tag, right after <
+  → as you type, the closing tag mirrors your input in real-time (multi-cursor style)
+  → the closing tag name highlights in blue as it syncs
+  → press ESC when done — both tags have the new name
+```
+
+Example: `cst` on `<div>foo</div>` → `<|>foo</>` → type `span` → `<span>foo</span>`
+
+**`csf` — In-place function name change:**
+
+```
+Press csf → labels on all function calls → pick one → function name deleted
+  → cursor enters insert mode at the name position
+  → type the new name directly in-place
+  → press ESC when done
+```
+
+Example: `csf` on `console.log(x)` → `|(x)` in insert mode → type `warn` → `warn(x)`
+
+Unlike `cs(` and `csq` which prompt for a replacement character, `cst` and `csf` use in-place insert mode editing. This is faster and more natural — you see the change happen live in the buffer.
+
+### Add Surround (`ys`)
+
+Fully composable — works with any motion and textobject:
+
+```
+ysaw(    ys + around + word + (  → labels on words → pick one → wraps with ( word )
+ysiw"    ys + inside + word + "  → wraps word under cursor with "word"
+ysaf{    ys + around + function + {  → labels on functions → pick one → wraps with { ... }
+ysab)    ys + around + block + )  → labels on blocks → pick one → wraps with (...)
+```
+
+Works with any composable motion (`w`, `b`, `e`) and textobjects (`f`, `c`, `a`).
+
+**Tag and function wrapping:**
+
+```
+ysiw t   → ys + inside + word + t → prompts "Tag:" → type "div" → <div>word</div>
+ysiw f   → ys + inside + word + f → prompts "Function:" → type "print" → print(word)
+```
+
+Visual `S` then type `t` also prompts for a tag name. `q` wraps with the nearest quote type.
+
+### Quick Surround Add (`gza`)
+
+```
+Press gza → keyword-only word labels appear → pick target → type ( → word becomes ( word )
+Press gza → pick target → type " → word becomes "word"
+```
+
+Faster than `ys` when you just want to wrap a single word.
+
+### Paste Surround (`gzp`)
+
+```
+ds( on foo(bar)  → parens removed, pair stored → bar
+gzp → word labels appear → pick "baz" → baz becomes (baz)
+```
+
+Re-wraps a target with the delimiter pair most recently removed by `ds`.
+
+### Target Expansion (`+`/`-`)
+
+After picking a target with `ys` or `gza`, you can **expand or shrink** the selection before typing the delimiter:
+
+| Key | What it does |
+|-----|--------------|
+| `+` | **Expand forward**: grow selection to include the next adjacent target |
+| `-` | **Expand backward**: grow selection to include the previous adjacent target |
+| `<BS>` | **Shrink**: undo the last expansion |
+| Any other key | **Confirm and execute**: the key is treated as the delimiter character |
+
+Dim `+`/`-` hints appear on adjacent targets so you can see what will be included next.
+
+```
+In: foo bar baz qux
+
+ysaw → labels on words → pick "foo" → "foo" highlights, dim +/- on adjacent words
+  press + → selection grows to "foo bar", dim +/- update
+  press + → selection grows to "foo bar baz"
+  type ( → result: ( foo bar baz )
+```
+
+```
+gza → labels on words → pick "bar" → "bar" highlights
+  press + → "bar baz"
+  press - → "bar baz" expands backward to "foo bar baz"
+  type " → result: "foo bar baz"
+```
+
+This is useful when you want to wrap a phrase or multi-word expression without switching to visual mode first. Just pick any word in the range and expand until the selection covers what you need.
+
+### Visual Surround (`S`)
+
+```
+Select text in visual mode → press S → type ( → selection wrapped with ( text )
+Select text → press S → type " → selection wrapped with "text"
+```
+
+No conflict with search preset `S` — search uses `n`/`o` modes, visual surround uses `x` mode.
+
+### Padding Convention
+
+| Delimiter | Padding | Example |
+|-----------|---------|---------|
+| `(` `{` `[` `<` (opening) | Yes | `( word )`, `{ word }` |
+| `)` `}` `]` `>` (closing) | No | `(word)`, `{word}` |
+| `"` `'` `` ` `` (quotes) | Never | `"word"`, `'word'` |
+
+Configurable via `surround_pad` in your config:
+- `"opening"` (default) — opening chars pad, closing chars don't
+- `"closing"` — reversed: closing chars pad, opening chars don't
+- `false` — no padding ever
+
+### How It Works
+
+Pair text objects use a **separate textobject registry** from composable motions. This means the same key can exist in both registries without conflict:
+
+- `f` as a composable motion = 2-char find
+- `f` as a textobject = function (from treesitter preset)
+
+The **key resolver** buffers input and resolves in priority order:
+1. Pre-set `textobject_key` (used by `ds`/`cs` operators)
+2. `i`/`a` prefix followed by a registered textobject key
+3. Composable motion lookup (existing behavior)
+
+**Pattern-based matching** provides a fallback when treesitter can't parse the buffer (e.g., while editing broken syntax). Pairs are found via pattern matching, so `di(` works even in a plain text file.
+
+**Dual-behavior textobjects:** The `f` textobject demonstrates how the same key can behave differently per prefix. `dif`/`daf` use the treesitter collector to target function bodies. `dsf` uses the `function_calls` collector to target function call expressions. This is achieved via `_collector_override` and `_extractor_override` fields in the surround motion_state, which swap the pipeline modules when the surround prefix is active.
+
+**Native fallback:** When an `i`/`a` key sequence doesn't match a registered textobject (like `w` in `diw`), it falls through to native vim. Your existing muscle memory works unchanged.
+
+---
+
 ## misc
 
 Repeat, history, pins, and multi-cursor operations.
@@ -509,6 +751,7 @@ presets = {
   git = true,
   quickfix = true,
   marks = true,
+  surround = true,
   misc = true,
 }
 ```
@@ -534,6 +777,11 @@ presets = {
   },
   search = {
     s = false,   -- keep native 's' (substitute)
+  },
+  surround = {
+    ds = false,  -- disable delete surround
+    S = false,   -- disable visual surround
+    gza = false, -- disable quick surround add
   },
 }
 ```

--- a/docs/Quick-Start.md
+++ b/docs/Quick-Start.md
@@ -26,6 +26,7 @@ Get SmartMotion running in 60 seconds.
       quickfix = true,
       marks = true,
       misc = true,
+      surround = true,   -- ds, cs, ys, gza, gzp, S + pair text objects + q/t/f
     },
   },
 }
@@ -52,6 +53,7 @@ use {
         quickfix = true,
         marks = true,
         misc = true,
+        surround = true,   -- ds, cs, ys, gza, gzp, S + pair text objects + q/t/f
       },
     })
   end,
@@ -82,11 +84,29 @@ Press `daf` → labels appear on all functions → select one → entire functio
 ### 6. Delete an Argument
 With cursor in a function call, press `daa` → labels appear on arguments → select one → argument deleted (including comma)
 
+### 7. Surround a Word
+Press `ys` → press `iw` → labels appear on words → select one → type `(` → word is wrapped in parentheses
+
+### 8. Delete Surrounding Delimiters
+Press `ds` → type `(` → the nearest parentheses around the cursor are removed, contents preserved
+
+### 9. Delete Surrounding Tags
+In an HTML file: `<div>hello</div>` → press `ds` → type `t` → labels on tags → pick one → tags removed → `hello`
+
+### 10. Unwrap a Function Call
+On `print(foo, bar)` → press `ds` → type `f` → labels on function calls → pick one → `foo, bar`
+
+### 11. Delete Nearest Quote (Any Type)
+Press `ds` → type `q` → labels appear on all `"`, `'`, `` ` `` pairs → pick one → quotes removed
+
+### 12. Expand a Target Before Surrounding
+Press `gza` → labels on words → pick a word → press `+` to expand forward → press `+` again → type `(` → multiple words wrapped in parentheses
+
 ---
 
 ## What You Just Got
 
-With all presets enabled, you have **140+ keybindings**:
+With all presets enabled, you have **160+ keybindings**:
 
 | Preset | Keys |
 |--------|------|
@@ -102,6 +122,7 @@ With all presets enabled, you have **140+ keybindings**:
 | **git** | `]g` `[g` |
 | **quickfix** | `]q` `[q` `]l` `[l` |
 | **marks** | `g'` `gm` |
+| **surround** | `ds` `cs` `ys` `gza` `gzp` `S` + pair text objects `()` `[]` `{}` `<>` `""` `''` `` `` `` + `q` `t` `f` |
 | **misc** | `.` `g.` `g0` `g1`-`g9` `gp` `gp1`-`gp9` `gP` `gA`-`gZ` `gmd` `gmy` |
 
 → See **[Presets Guide](Presets.md)** for detailed explanations of each.

--- a/docs/Why-SmartMotion.md
+++ b/docs/Why-SmartMotion.md
@@ -251,6 +251,78 @@ Other plugins offer limited customization: change some options, maybe define a c
 
 ---
 
+### vs. nvim-surround
+
+**nvim-surround** is the standard surround plugin for Neovim. It provides `ds`, `cs`, `ys`, and visual `S` with good defaults and broad delimiter support.
+
+| Aspect | nvim-surround | SmartMotion |
+|--------|---------------|-------------|
+| Delete surround (`ds`) | ✓ (acts on nearest) | ✓ (labels all pairs, you pick) |
+| Change surround (`cs`) | ✓ (acts on nearest) | ✓ (labels all pairs, you pick) |
+| Add surround (`ys`) | ✓ | ✓ |
+| Visual surround (`S`) | ✓ | ✓ |
+| Label-based target picking | | ✓ |
+| Target expansion (+/-) | | ✓ |
+| Visual feedback during prompts | | ✓ |
+| Pair detection fallback | | ✓ (pattern when treesitter fails) |
+| Composes with motion labels | | ✓ (`ysaw` shows word labels) |
+| Composes with textobjects | | ✓ (`ysaf` shows function labels) |
+| Function call surround (`dsf`/`csf`) | ✓ | ✓ |
+| HTML/tag support (`dst`/`cst`) | ✓ | ✓ |
+| Quote alias (`dsq`/`csq`) | | ✓ |
+| Part of a motion system | | ✓ (shared pipeline, history, flow state) |
+| Custom surround definitions | ✓ (functions, callbacks) | Via pair_defs registry |
+| Maturity / edge cases | ✓ (years of fixes) | Newer |
+
+**Where nvim-surround wins**: Extensive custom surround definitions (you can define surround functions that produce arbitrary output) and maturity. nvim-surround has years of edge-case fixes and a large user base. If you need surround functions that call Lua callbacks for arbitrary output, nvim-surround has deeper support for that use case.
+
+**Where SmartMotion wins**:
+
+- **Label-based target picking.** With nvim-surround, `ds(` deletes the nearest `()` pair to your cursor. With SmartMotion, `ds(` labels every `()` pair on screen and you pick which one, even if it's not the one surrounding your cursor. The same applies to `cs`.
+- **Target expansion.** After picking a target with `ys` or `gza`, press `+` to expand forward or `-` to expand backward before typing the delimiter. This lets you wrap multi-word phrases without switching to visual mode. No other surround plugin offers this.
+- **Visual feedback.** SmartMotion highlights selected delimiters during `cs` and highlights the target region during `ys` so you can see exactly what you're about to change or wrap. nvim-surround has no visual feedback during prompts.
+- **Pipeline composability.** `ys` composes with SmartMotion's full motion and textobject systems: `ysaw` shows labeled words, `ysaf` shows labeled functions. Custom collectors, filters, and visualizers work with surround operations too.
+- **Pattern-based fallback.** SmartMotion's pair detection works even when treesitter can't parse the buffer (common while actively editing broken syntax).
+- **Tag and function call support.** SmartMotion now matches nvim-surround on `dst`/`cst` (HTML/XML tags) and `dsf`/`csf` (function calls), plus adds `dsq`/`csq` for targeting any quote type at once.
+- **Live multi-cursor tag rename.** nvim-surround's `cst` uses a command-line prompt to read the new tag name, then replaces both tags. SmartMotion's `cst` deletes the tag name from both opening and closing tags, enters insert mode in the opening tag, and mirrors your keystrokes to the closing tag in real-time. You see both tags update as you type. `csf` similarly uses in-place insert mode instead of a prompt.
+
+---
+
+### vs. mini.surround
+
+**mini.surround** is part of the excellent mini.nvim ecosystem. It provides surround add/delete/change/find/highlight with a consistent interface and minimal configuration.
+
+| Aspect | mini.surround | SmartMotion |
+|--------|---------------|-------------|
+| Delete surround | ✓ (acts on nearest) | ✓ (labels all pairs, you pick) |
+| Change surround | ✓ (acts on nearest) | ✓ (labels all pairs, you pick) |
+| Add surround | ✓ | ✓ |
+| Visual surround | ✓ | ✓ |
+| Find surround | ✓ | |
+| Highlight surround | ✓ | |
+| Label-based target picking | | ✓ |
+| Target expansion (+/-) | | ✓ |
+| Visual feedback during prompts | | ✓ |
+| Composes with motion labels | | ✓ |
+| Part of a motion system | | ✓ |
+| Function call surround (`dsf`/`csf`) | | ✓ |
+| HTML/tag support (`dst`/`cst`) | ✓ | ✓ |
+| Quote alias (`dsq`/`csq`) | | ✓ |
+| Custom surround specs | ✓ (input/output patterns) | Via pair_defs registry |
+| mini.nvim ecosystem | ✓ | |
+
+**Where mini.surround wins**: If you're invested in the mini.nvim ecosystem, mini.surround fits naturally alongside mini.ai, mini.pairs, mini.jump, etc. It has find-surround and highlight-surround features that SmartMotion doesn't replicate. Custom surround specifications via input/output patterns are flexible. It's lightweight and well-tested.
+
+**Where SmartMotion wins**:
+
+- **Label-based target picking.** mini.surround operates on the nearest matching pair. SmartMotion labels all matching pairs and lets you pick any one, regardless of cursor proximity.
+- **Target expansion.** Press `+`/`-` after picking a target to grow or shrink the selection before wrapping. This lets you surround multi-word expressions without pre-selecting in visual mode.
+- **Visual feedback.** SmartMotion highlights delimiters and target regions during surround prompts. mini.surround highlights the nearest surround briefly but doesn't show what you're about to act on during the operation itself.
+- **Pipeline composability.** Surround operations in SmartMotion use the same pipeline as all other motions. Custom collectors, filters, visualizers, and the full textobject system are available to surround operations.
+- **Live multi-cursor tag rename.** `cst` deletes the tag name from both opening and closing tags, enters insert mode, and mirrors keystrokes to the closing tag in real-time. `csf` uses in-place insert mode for function name changes. No command-line prompts.
+
+---
+
 ## What You Consolidate
 
 With all presets enabled, SmartMotion can replace several plugins at once:
@@ -262,9 +334,10 @@ flash.nvim (motions + search)                   smart-motion.nvim
 harpoon (file pins + quick navigation)            with one opts table
 nvim-treesitter-textobjects (af/if/ac/ic)
 mini.ai (around/inside text objects)
+nvim-surround (ds/cs/ys + tags/functions/quotes)
 ```
 
-One plugin, one config, and everything composes with everything else. Your pin system knows about your motion history. Your text objects work with flow state. Your operators compose with motions you haven't even thought of yet.
+One plugin, one config, and everything composes with everything else. Your pin system knows about your motion history. Your text objects work with flow state. Your surround operations compose with your motions and textobjects. Your operators compose with motions you haven't even thought of yet.
 
 This isn't about replacing good plugins for the sake of it. It's about the compound benefits you get when these features share an architecture. A motion recorded in history carries its full context: you can replay it, pin it, or act on it remotely. A text object uses the same labeling system as your search motions. An operator infers its pipeline from any composable motion, including ones you build yourself.
 

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -8,6 +8,8 @@
 **Using SmartMotion**
 - [Presets Guide](Presets)
 - [Advanced Features](Advanced-Features)
+  - [Textobject System](Advanced-Features#textobject-system)
+  - [Surround Operations](Advanced-Features#surround-operations)
 
 **Customizing**
 - [Recipes](Recipes)

--- a/lua/smart-motion/actions/README.md
+++ b/lua/smart-motion/actions/README.md
@@ -61,6 +61,10 @@ Actions follow a naming pattern:
 | `delete_jump`, `yank_jump`, `change_jump` | Jump to target first, then operate | Composable operators (`dw`, `yw`, `cj`) |
 | `remote_delete` | Jump, operate, restore cursor | Remote presets (`rdw`) |
 | `*_line` | Line-wise variant | Double-tap (`dd`, `yy`, `cc`) |
+| `surround` | Dispatch surround operations (delete/yank/change delimiters) based on `action_key` | Surround presets (`ds`, `cs`) |
+| `surround_add` | Wrap target with prompted delimiter pair | `ys`, `gza` flows |
+| `surround_paste` | Wrap target with previously yanked delimiter pair | `gzp` |
+| `surround_visual` | Wrap visual selection with prompted delimiter | Visual `S` |
 
 The `*_jump` variants have `keys` registered in the action registry (e.g., `delete_jump` has `keys = { "d" }`). This is how the infer system resolves the correct action when composable operators look up their action by key.
 
@@ -73,4 +77,8 @@ The `*_jump` variants have `keys` registered in the action registry (e.g., `dele
 | Delete/yank/change without moving | `delete`, `yank`, `change` |
 | Paste at a target | `paste_jump`, `paste_line` |
 | Remote operations | `remote_delete` |
+| Surround delete/yank/change | `surround` |
+| Wrap target with delimiter | `surround_add` |
+| Wrap target with yanked delimiter | `surround_paste` |
+| Wrap visual selection with delimiter | `surround_visual` |
 | Repeat a motion | `run_motion` |

--- a/lua/smart-motion/actions/change.lua
+++ b/lua/smart-motion/actions/change.lua
@@ -18,8 +18,10 @@ function M.run(ctx, cfg, motion_state)
 		text = table.concat(lines, "\n")
 		regtype = "l"
 		utils.set_register(bufnr, start_row, start_col, end_row, end_col, text, regtype, "c")
-		vim.api.nvim_buf_set_lines(bufnr, start_row, end_row + 1, false, { "" })
-		vim.api.nvim_win_set_cursor(winid, { start_row + 1, 0 })
+		-- Preserve indentation of the first line
+		local indent = lines[1] and lines[1]:match("^(%s*)") or ""
+		vim.api.nvim_buf_set_lines(bufnr, start_row, end_row + 1, false, { indent })
+		vim.api.nvim_win_set_cursor(winid, { start_row + 1, #indent })
 	else
 		local lines = vim.api.nvim_buf_get_text(bufnr, start_row, start_col, end_row, end_col, {})
 		text = table.concat(lines, "\n")

--- a/lua/smart-motion/actions/init.lua
+++ b/lua/smart-motion/actions/init.lua
@@ -199,6 +199,27 @@ local action_entries = {
 			description = "Sets a charwise visual selection spanning the target range",
 		},
 	},
+	surround = {
+		run = require("smart-motion.actions.surround").run,
+		metadata = {
+			label = "Surround",
+			description = "Performs surround operations (delete/yank/change delimiters)",
+		},
+	},
+	surround_add = {
+		run = require("smart-motion.actions.surround_add").run,
+		metadata = {
+			label = "Surround Add",
+			description = "Wraps a target with a prompted delimiter pair",
+		},
+	},
+	surround_paste = {
+		run = require("smart-motion.actions.surround_paste").run,
+		metadata = {
+			label = "Surround Paste",
+			description = "Wraps a target with the previously yanked delimiter pair",
+		},
+	},
 	run_motion = run_motion,
 }
 

--- a/lua/smart-motion/actions/surround.lua
+++ b/lua/smart-motion/actions/surround.lua
@@ -1,0 +1,450 @@
+local pair_defs = require("smart-motion.utils.pair_defs")
+local action_utils = require("smart-motion.actions.utils")
+local consts = require("smart-motion.consts")
+local highlight_mod = require("smart-motion.core.highlight")
+local log = require("smart-motion.core.log")
+
+---@type SmartMotionActionModuleEntry
+local M = {}
+
+--- Deletes delimiter characters from the buffer.
+--- Removes close delimiter first to preserve positions.
+--- When the user typed an opening char (e.g. ds( ), also strips inner padding.
+--- @param ctx SmartMotionContext
+--- @param motion_state SmartMotionMotionState
+local function _delete_delimiters(ctx, motion_state)
+	local target = motion_state.selected_jump_target
+	local meta = target.metadata
+	local bufnr = target.metadata.bufnr
+
+	local open_pos = meta.open_pos
+	local close_pos = meta.close_pos
+
+	-- Check if the user typed the opening char (pad-aware deletion)
+	local pair_info = motion_state.motion_key and pair_defs.get_pair(motion_state.motion_key)
+	local strip_padding = pair_info and pair_info.pad
+
+	-- Compute close delete range (optionally strip leading space)
+	local close_start_row, close_start_col = close_pos.start.row, close_pos.start.col
+	if strip_padding and close_start_col > 0 then
+		local line = vim.api.nvim_buf_get_lines(bufnr, close_start_row, close_start_row + 1, false)[1]
+		if line and line:sub(close_start_col, close_start_col) == " " then
+			close_start_col = close_start_col - 1
+		end
+	end
+
+	-- Compute open delete range (optionally strip trailing space)
+	local open_end_row, open_end_col = open_pos["end"].row, open_pos["end"].col
+	if strip_padding then
+		local line = vim.api.nvim_buf_get_lines(bufnr, open_end_row, open_end_row + 1, false)[1]
+		if line and line:sub(open_end_col + 1, open_end_col + 1) == " " then
+			open_end_col = open_end_col + 1
+		end
+	end
+
+	-- Join both edits into one undo step (pcall: may fail after undo)
+	pcall(vim.cmd, "undojoin")
+
+	-- Delete close delimiter first (preserves open positions)
+	vim.api.nvim_buf_set_text(
+		bufnr,
+		close_start_row,
+		close_start_col,
+		close_pos["end"].row,
+		close_pos["end"].col,
+		{ "" }
+	)
+
+	vim.cmd("undojoin")
+
+	-- Delete open delimiter
+	vim.api.nvim_buf_set_text(
+		bufnr,
+		open_pos.start.row,
+		open_pos.start.col,
+		open_end_row,
+		open_end_col,
+		{ "" }
+	)
+
+	log.debug(string.format(
+		"surround delete: removed '%s' at %d:%d and '%s' at %d:%d",
+		meta.pair_open,
+		open_pos.start.row,
+		open_pos.start.col,
+		meta.pair_close,
+		close_pos.start.row,
+		close_pos.start.col
+	))
+end
+
+--- Yanks delimiter characters to the register.
+--- @param ctx SmartMotionContext
+--- @param motion_state SmartMotionMotionState
+local function _yank_delimiters(ctx, motion_state)
+	local target = motion_state.selected_jump_target
+	local meta = target.metadata
+	local bufnr = target.metadata.bufnr
+
+	local text = meta.pair_open .. meta.pair_close
+
+	action_utils.set_register(
+		bufnr,
+		meta.open_pos.start.row,
+		meta.open_pos.start.col,
+		meta.close_pos["end"].row,
+		meta.close_pos["end"].col,
+		text,
+		"c",
+		"y"
+	)
+
+	-- Store pair for paste surround
+	vim.g.smart_motion_surround_pair = text
+
+	log.debug(string.format("surround yank: yanked '%s'", text))
+end
+
+--- Highlights the open and close delimiters with SmartMotionSelected.
+--- Returns extmark IDs for cleanup.
+--- @param bufnr number
+--- @param open_pos table
+--- @param close_pos table
+--- @return number[] extmark_ids
+local function _highlight_delimiters(bufnr, open_pos, close_pos)
+	local ids = {}
+	ids[#ids + 1] = vim.api.nvim_buf_set_extmark(bufnr, consts.ns_id, open_pos.start.row, open_pos.start.col, {
+		end_row = open_pos["end"].row,
+		end_col = open_pos["end"].col,
+		hl_group = "SmartMotionSelected",
+	})
+	ids[#ids + 1] = vim.api.nvim_buf_set_extmark(bufnr, consts.ns_id, close_pos.start.row, close_pos.start.col, {
+		end_row = close_pos["end"].row,
+		end_col = close_pos["end"].col,
+		hl_group = "SmartMotionSelected",
+	})
+	vim.cmd("redraw")
+	return ids
+end
+
+--- Clears extmarks created by _highlight_delimiters.
+--- @param bufnr number
+--- @param ids number[]
+local function _clear_delimiter_highlights(bufnr, ids)
+	for _, id in ipairs(ids) do
+		vim.api.nvim_buf_del_extmark(bufnr, consts.ns_id, id)
+	end
+end
+
+--- Changes delimiter characters by prompting for a replacement.
+--- @param ctx SmartMotionContext
+--- @param cfg SmartMotionConfig
+--- @param motion_state SmartMotionMotionState
+local function _change_delimiters(ctx, cfg, motion_state)
+	local target = motion_state.selected_jump_target
+	local meta = target.metadata
+	local bufnr = target.metadata.bufnr
+
+	-- Clear hint labels before showing the selected delimiters
+	highlight_mod.clear(ctx, cfg, motion_state)
+
+	-- Highlight the selected delimiters so the user sees what they're changing
+	local hl_ids = _highlight_delimiters(bufnr, meta.open_pos, meta.close_pos)
+
+	-- Prompt for replacement character
+	local ok, raw = pcall(vim.fn.getchar)
+
+	-- Clean up highlights regardless of outcome
+	_clear_delimiter_highlights(bufnr, hl_ids)
+
+	if not ok then
+		return
+	end
+	local char = type(raw) == "number" and vim.fn.nr2char(raw) or raw
+	if char == "\027" then
+		return
+	end -- ESC cancels
+
+	local new_pair = pair_defs.get_pair(char)
+	if not new_pair then
+		log.debug("surround change: invalid pair character '" .. char .. "'")
+		return
+	end
+
+	-- Special pairs (tag, function) need a name prompt
+	if new_pair.special then
+		local name = vim.fn.input(new_pair.prompt)
+		new_pair = pair_defs.build_special_pair(new_pair.special, name)
+		if not new_pair then
+			return
+		end
+	end
+
+	local open_pos = meta.open_pos
+	local close_pos = meta.close_pos
+
+	-- Check if the source char (what the user typed for cs) is pad-aware
+	local source_info = motion_state.motion_key and pair_defs.get_pair(motion_state.motion_key)
+	local strip_padding = source_info and not source_info.special and source_info.pad
+
+	-- New replacement text (opening char of replacement adds padding)
+	local open_text = new_pair.pad and (new_pair.open .. " ") or new_pair.open
+	local close_text = new_pair.pad and (" " .. new_pair.close) or new_pair.close
+
+	-- Compute close replace range (optionally strip leading space from old delimiter)
+	local close_start_row, close_start_col = close_pos.start.row, close_pos.start.col
+	if strip_padding and close_start_col > 0 then
+		local line = vim.api.nvim_buf_get_lines(bufnr, close_start_row, close_start_row + 1, false)[1]
+		if line and line:sub(close_start_col, close_start_col) == " " then
+			close_start_col = close_start_col - 1
+		end
+	end
+
+	-- Compute open replace range (optionally strip trailing space from old delimiter)
+	local open_end_row, open_end_col = open_pos["end"].row, open_pos["end"].col
+	if strip_padding then
+		local line = vim.api.nvim_buf_get_lines(bufnr, open_end_row, open_end_row + 1, false)[1]
+		if line and line:sub(open_end_col + 1, open_end_col + 1) == " " then
+			open_end_col = open_end_col + 1
+		end
+	end
+
+	-- Join both edits into one undo step (pcall: may fail after undo)
+	pcall(vim.cmd, "undojoin")
+
+	-- Replace close delimiter first (preserves open positions)
+	vim.api.nvim_buf_set_text(
+		bufnr,
+		close_start_row,
+		close_start_col,
+		close_pos["end"].row,
+		close_pos["end"].col,
+		{ close_text }
+	)
+
+	vim.cmd("undojoin")
+
+	-- Replace open delimiter
+	vim.api.nvim_buf_set_text(
+		bufnr,
+		open_pos.start.row,
+		open_pos.start.col,
+		open_end_row,
+		open_end_col,
+		{ open_text }
+	)
+
+	log.debug(string.format(
+		"surround change: replaced '%s%s' with '%s%s'",
+		meta.pair_open,
+		meta.pair_close,
+		new_pair.open,
+		new_pair.close
+	))
+end
+
+--- Changes a function call name: deletes the name, keeps parens, enters insert mode.
+--- @param ctx SmartMotionContext
+--- @param cfg SmartMotionConfig
+--- @param motion_state SmartMotionMotionState
+local function _change_function_name(ctx, cfg, motion_state)
+	local target = motion_state.selected_jump_target
+	local meta = target.metadata
+	local bufnr = target.metadata.bufnr
+	local winid = target.metadata.winid or 0
+
+	-- open_pos spans "funcname(" — we want to delete just "funcname" (not the paren)
+	local open_pos = meta.open_pos
+	local name_end_col = open_pos["end"].col - 1 -- exclude the "("
+
+	-- Clear hint labels
+	highlight_mod.clear(ctx, cfg, motion_state)
+
+	pcall(vim.cmd, "undojoin")
+
+	-- Delete the function name (keep the paren)
+	vim.api.nvim_buf_set_text(
+		bufnr,
+		open_pos.start.row,
+		open_pos.start.col,
+		open_pos.start.row,
+		name_end_col,
+		{ "" }
+	)
+
+	-- Position cursor at where the name was and enter insert mode
+	vim.api.nvim_win_set_cursor(winid, { open_pos.start.row + 1, open_pos.start.col })
+	vim.cmd("startinsert")
+
+	log.debug("surround change function: removed name, entering insert mode")
+end
+
+--- Changes an HTML/XML tag name with live sync: as you type in the opening tag,
+--- the closing tag mirrors it in real-time (multi-cursor style).
+--- @param ctx SmartMotionContext
+--- @param cfg SmartMotionConfig
+--- @param motion_state SmartMotionMotionState
+local function _change_tag_name(ctx, cfg, motion_state)
+	local target = motion_state.selected_jump_target
+	local meta = target.metadata
+	local bufnr = target.metadata.bufnr
+	local winid = target.metadata.winid or 0
+	local old_name = meta.tag_name
+
+	local open_pos = meta.open_pos
+	local close_pos = meta.close_pos
+
+	-- Clear hint labels
+	highlight_mod.clear(ctx, cfg, motion_state)
+
+	pcall(vim.cmd, "undojoin")
+
+	local open_row = open_pos.start.row
+	local open_name_start = open_pos.start.col + 1 -- after "<"
+	local open_name_end = open_name_start + #old_name
+	local close_row = close_pos.start.row
+
+	-- Delete close tag name first (preserves open tag positions)
+	local close_name_start = close_pos.start.col + 2 -- after "</"
+	local close_name_end = close_name_start + #old_name
+	vim.api.nvim_buf_set_text(bufnr, close_row, close_name_start, close_row, close_name_end, { "" })
+
+	vim.cmd("undojoin")
+
+	-- Delete open tag name
+	vim.api.nvim_buf_set_text(bufnr, open_row, open_name_start, open_row, open_name_end, { "" })
+
+	-- Track what we've synced so far
+	local last_synced_name = ""
+
+	--- Find the close tag "</>" name insertion point by scanning the actual line.
+	--- Returns the column right after "</" where the name should go.
+	local function find_close_name_col()
+		local close_line = vim.api.nvim_buf_get_lines(bufnr, close_row, close_row + 1, false)[1]
+		if not close_line then
+			return nil
+		end
+		-- Find "</" followed by the current synced name (or empty)
+		local pattern = "</" .. vim.pesc(last_synced_name)
+		local s = close_line:find(pattern, 1, true)
+		if s then
+			return s - 1 + 2 -- 0-indexed, after "</"
+		end
+		return nil
+	end
+
+	-- Highlight the close tag
+	local init_col = find_close_name_col()
+	local close_hl_id = nil
+	if init_col then
+		close_hl_id = vim.api.nvim_buf_set_extmark(bufnr, consts.ns_id, close_row, init_col, {
+			virt_text = { { "|", "SmartMotionSelected" } },
+			virt_text_pos = "inline",
+		})
+	end
+
+	-- Set up live sync: mirror every keystroke to the close tag
+	local augroup = vim.api.nvim_create_augroup("SmartMotionTagSync", { clear = true })
+
+	vim.api.nvim_create_autocmd({ "TextChangedI", "TextChangedP" }, {
+		group = augroup,
+		buffer = bufnr,
+		callback = function()
+			-- Read current name from opening tag
+			local line = vim.api.nvim_buf_get_lines(bufnr, open_row, open_row + 1, false)[1]
+			if not line then
+				return
+			end
+
+			local after_bracket = line:sub(open_name_start + 1)
+			local new_name = after_bracket:match("^([%w_%-%.%:]*)") or ""
+
+			if new_name == last_synced_name then
+				return
+			end
+
+			-- Find where the close tag name currently is
+			local col = find_close_name_col()
+			if not col then
+				return
+			end
+
+			local close_current_end = col + #last_synced_name
+
+			pcall(vim.cmd, "undojoin")
+			pcall(vim.api.nvim_buf_set_text,
+				bufnr, close_row, col, close_row, close_current_end, { new_name })
+
+			last_synced_name = new_name
+
+			-- Update highlight on the close tag name
+			if close_hl_id then
+				pcall(vim.api.nvim_buf_del_extmark, bufnr, consts.ns_id, close_hl_id)
+			end
+			local new_col = find_close_name_col()
+			if new_col then
+				close_hl_id = vim.api.nvim_buf_set_extmark(bufnr, consts.ns_id, close_row, new_col, {
+					end_row = close_row,
+					end_col = new_col + #new_name,
+					hl_group = "SmartMotionSelected",
+				})
+			end
+		end,
+	})
+
+	-- Clean up on InsertLeave
+	vim.api.nvim_create_autocmd("InsertLeave", {
+		group = augroup,
+		buffer = bufnr,
+		once = true,
+		callback = function()
+			vim.api.nvim_del_augroup_by_id(augroup)
+			pcall(vim.api.nvim_buf_del_extmark, bufnr, consts.ns_id, close_hl_id)
+			log.debug(string.format("surround change tag: '%s' → '%s'", old_name, last_synced_name))
+		end,
+	})
+
+	-- Position cursor and enter insert mode
+	vim.api.nvim_win_set_cursor(winid, { open_row + 1, open_name_start })
+	vim.cmd("startinsert")
+end
+
+--- Dispatching action for surround operations.
+--- Checks motion_state.motion.action_key to determine operation.
+---@param ctx SmartMotionContext
+---@param cfg SmartMotionConfig
+---@param motion_state SmartMotionMotionState
+function M.run(ctx, cfg, motion_state)
+	local action_key = motion_state.motion.action_key
+	local meta = motion_state.selected_jump_target and motion_state.selected_jump_target.metadata
+
+	-- Tag special handling
+	if meta and meta.tag_name then
+		if action_key == "c" then
+			_change_tag_name(ctx, cfg, motion_state)
+			return
+		end
+		-- dst falls through to normal _delete_delimiters (removes both tags)
+	end
+
+	-- Function call special handling
+	if meta and meta.func_name then
+		if action_key == "c" then
+			_change_function_name(ctx, cfg, motion_state)
+			return
+		end
+		-- dsf falls through to normal _delete_delimiters (removes name+parens)
+	end
+
+	if action_key == "d" then
+		_delete_delimiters(ctx, motion_state)
+	elseif action_key == "y" then
+		_yank_delimiters(ctx, motion_state)
+	elseif action_key == "c" then
+		_change_delimiters(ctx, cfg, motion_state)
+	else
+		log.debug("surround: unsupported action_key '" .. tostring(action_key) .. "'")
+	end
+end
+
+return M

--- a/lua/smart-motion/actions/surround_add.lua
+++ b/lua/smart-motion/actions/surround_add.lua
@@ -1,0 +1,84 @@
+local pair_defs = require("smart-motion.utils.pair_defs")
+local consts = require("smart-motion.consts")
+local highlight = require("smart-motion.core.highlight")
+local log = require("smart-motion.core.log")
+
+---@type SmartMotionActionModuleEntry
+local M = {}
+
+--- Surround add: after target is selected, prompt for delimiter and wrap.
+--- Used by both `gza` (standalone) and `ys` (infer operator) flows.
+---@param ctx SmartMotionContext
+---@param cfg SmartMotionConfig
+---@param motion_state SmartMotionMotionState
+function M.run(ctx, cfg, motion_state)
+	local target = motion_state.selected_jump_target
+	if not target then
+		log.debug("surround_add: no selected target")
+		return
+	end
+
+	local bufnr = target.metadata.bufnr
+	local sr = target.start_pos.row
+	local sc = target.start_pos.col
+	local er = target.end_pos.row
+	local ec = target.end_pos.col
+
+	-- Clear hint labels before showing the selected target
+	highlight.clear(ctx, cfg, motion_state)
+
+	-- Highlight the target so the user sees what will be wrapped
+	local hl_id = vim.api.nvim_buf_set_extmark(bufnr, consts.ns_id, sr, sc, {
+		end_row = er,
+		end_col = ec,
+		hl_group = "SmartMotionSelected",
+	})
+	vim.cmd("redraw")
+
+	-- Prompt for delimiter character
+	local ok, raw = pcall(vim.fn.getchar)
+
+	-- Clean up highlight regardless of outcome
+	vim.api.nvim_buf_del_extmark(bufnr, consts.ns_id, hl_id)
+
+	if not ok then
+		return
+	end
+	local char = type(raw) == "number" and vim.fn.nr2char(raw) or raw
+	if char == "\027" then
+		return
+	end -- ESC cancels
+
+	local pair = pair_defs.get_pair(char)
+	if not pair then
+		log.debug("surround_add: invalid pair character '" .. char .. "'")
+		return
+	end
+
+	-- Special pairs (tag, function) need a name prompt
+	if pair.special then
+		local name = vim.fn.input(pair.prompt)
+		pair = pair_defs.build_special_pair(pair.special, name)
+		if not pair then
+			return
+		end
+	end
+
+	local open_text = pair.pad and (pair.open .. " ") or pair.open
+	local close_text = pair.pad and (" " .. pair.close) or pair.close
+
+	-- Join both edits into one undo step (pcall: may fail after undo)
+	pcall(vim.cmd, "undojoin")
+
+	-- Insert close delimiter first (preserves start positions)
+	vim.api.nvim_buf_set_text(bufnr, er, ec, er, ec, { close_text })
+
+	vim.cmd("undojoin")
+
+	-- Insert open delimiter
+	vim.api.nvim_buf_set_text(bufnr, sr, sc, sr, sc, { open_text })
+
+	log.debug(string.format("surround_add: wrapped with '%s%s'", open_text, close_text))
+end
+
+return M

--- a/lua/smart-motion/actions/surround_paste.lua
+++ b/lua/smart-motion/actions/surround_paste.lua
@@ -1,0 +1,49 @@
+local log = require("smart-motion.core.log")
+
+---@type SmartMotionActionModuleEntry
+local M = {}
+
+--- Standalone surround paste: wrap target with previously yanked pair.
+--- Reads pair from vim.g.smart_motion_surround_pair (set by ysi( etc.).
+--- Mapped to `gzp` in normal mode.
+---@param ctx SmartMotionContext
+---@param cfg SmartMotionConfig
+---@param motion_state SmartMotionMotionState
+function M.run(ctx, cfg, motion_state)
+	local target = motion_state.selected_jump_target
+	if not target then
+		log.debug("surround_paste: no selected target")
+		return
+	end
+
+	local stored = vim.g.smart_motion_surround_pair
+	if not stored or #stored < 2 then
+		log.debug("surround_paste: no stored surround pair (use ysi( first)")
+		return
+	end
+
+	local bufnr = target.metadata.bufnr
+	local sr = target.start_pos.row
+	local sc = target.start_pos.col
+	local er = target.end_pos.row
+	local ec = target.end_pos.col
+
+	-- Extract open and close from stored pair string
+	local open_char = stored:sub(1, 1)
+	local close_char = stored:sub(2, 2)
+
+	-- Join both edits into one undo step (pcall: may fail after undo)
+	pcall(vim.cmd, "undojoin")
+
+	-- Insert close delimiter first (preserves start positions)
+	vim.api.nvim_buf_set_text(bufnr, er, ec, er, ec, { close_char })
+
+	vim.cmd("undojoin")
+
+	-- Insert open delimiter
+	vim.api.nvim_buf_set_text(bufnr, sr, sc, sr, sc, { open_char })
+
+	log.debug(string.format("surround_paste: wrapped with '%s%s'", open_char, close_char))
+end
+
+return M

--- a/lua/smart-motion/actions/surround_visual.lua
+++ b/lua/smart-motion/actions/surround_visual.lua
@@ -1,0 +1,77 @@
+local pair_defs = require("smart-motion.utils.pair_defs")
+local consts = require("smart-motion.consts")
+local log = require("smart-motion.core.log")
+
+---@type SmartMotionActionModuleEntry
+local M = {}
+
+--- Visual surround: wrap visual selection with prompted delimiter.
+--- Mapped to `S` in visual mode.
+function M.run()
+	-- Exit visual mode to set marks, then read them
+	vim.cmd("normal! \27")
+
+	local start_pos = vim.fn.getpos("'<")
+	local end_pos = vim.fn.getpos("'>")
+	local sr = start_pos[2] - 1 -- 0-indexed
+	local sc = start_pos[3] - 1
+	local er = end_pos[2] - 1
+	local ec = end_pos[3] -- exclusive end for nvim_buf_set_text
+
+	local bufnr = vim.api.nvim_get_current_buf()
+
+	-- Highlight the selection so the user sees what will be wrapped
+	local hl_id = vim.api.nvim_buf_set_extmark(bufnr, consts.ns_id, sr, sc, {
+		end_row = er,
+		end_col = ec,
+		hl_group = "SmartMotionSelected",
+	})
+	vim.cmd("redraw")
+
+	-- Prompt for delimiter character
+	local ok, raw = pcall(vim.fn.getchar)
+
+	-- Clean up highlight regardless of outcome
+	vim.api.nvim_buf_del_extmark(bufnr, consts.ns_id, hl_id)
+
+	if not ok then
+		return
+	end
+	local char = type(raw) == "number" and vim.fn.nr2char(raw) or raw
+	if char == "\027" then
+		return
+	end -- ESC cancels
+
+	local pair = pair_defs.get_pair(char)
+	if not pair then
+		log.debug("surround_visual: invalid pair character '" .. char .. "'")
+		return
+	end
+
+	-- Special pairs (tag, function) need a name prompt
+	if pair.special then
+		local name = vim.fn.input(pair.prompt)
+		pair = pair_defs.build_special_pair(pair.special, name)
+		if not pair then
+			return
+		end
+	end
+
+	local open_text = pair.pad and (pair.open .. " ") or pair.open
+	local close_text = pair.pad and (" " .. pair.close) or pair.close
+
+	-- Join both edits into one undo step (pcall: may fail after undo)
+	pcall(vim.cmd, "undojoin")
+
+	-- Insert close delimiter after selection end first (preserves start positions)
+	vim.api.nvim_buf_set_text(bufnr, er, ec, er, ec, { close_text })
+
+	vim.cmd("undojoin")
+
+	-- Insert open delimiter before selection start
+	vim.api.nvim_buf_set_text(bufnr, sr, sc, sr, sc, { open_text })
+
+	log.debug(string.format("surround_visual: wrapped selection with '%s%s'", open_text, close_text))
+end
+
+return M

--- a/lua/smart-motion/actions/utils.lua
+++ b/lua/smart-motion/actions/utils.lua
@@ -22,6 +22,11 @@ end
 function M.resolve_range(ctx, motion_state)
 	local target = motion_state.selected_jump_target
 
+	-- Expanded range: always use the full synthesized range, skip cursor-based adjustments
+	if motion_state.is_expanded_range then
+		return target.start_pos.row, target.start_pos.col, target.end_pos.row, target.end_pos.col
+	end
+
 	if motion_state.exclude_target then
 		local cursor_before = ctx.cursor_line < target.start_pos.row
 			or (ctx.cursor_line == target.start_pos.row and ctx.cursor_col < target.start_pos.col)

--- a/lua/smart-motion/collectors/README.md
+++ b/lua/smart-motion/collectors/README.md
@@ -70,6 +70,24 @@ Collects `vim.diagnostic.get()` results as targets with position, message, sever
 
 ---
 
+## Example: `pairs.lua` (Collecting Delimiter Pairs)
+
+Collects matching delimiter pairs in the visible buffer. Tries treesitter first for accuracy, falls back to pattern-based scanning when the tree has errors (common while editing).
+
+---
+
+## Example: `tags.lua` (Collecting HTML/XML Tag Pairs)
+
+Collects matching HTML/XML tag pairs (`<div>...</div>`) in the visible buffer. Uses treesitter for HTML/JSX/TSX files where tag nodes exist in the syntax tree, and falls back to pattern-based scanning (`<tagname ...>...</tagname>`) for other file types.
+
+---
+
+## Example: `function_calls.lua` (Collecting Function Call Expressions)
+
+Collects function call expressions (e.g., `print(foo, bar)`) in the visible buffer. Uses treesitter `call_expression` nodes when available, with a pattern-based fallback that matches `identifier(...)` patterns. Used by the `f` textobject's surround override (`dsf`, `csf`) to target function calls rather than function definitions.
+
+---
+
 ## When to Use a Collector?
 
 | Use Case | Example Collector |
@@ -78,3 +96,6 @@ Collects `vim.diagnostic.get()` results as targets with position, message, sever
 | Getting treesitter nodes (functions, classes, arguments) | `treesitter` |
 | Getting LSP diagnostics | `diagnostics` |
 | Getting jump history entries | `history` |
+| Getting matching delimiter pairs in visible buffer | `pairs` |
+| Getting HTML/XML tag pairs in visible buffer | `tags` |
+| Getting function call expressions in visible buffer | `function_calls` |

--- a/lua/smart-motion/collectors/function_calls.lua
+++ b/lua/smart-motion/collectors/function_calls.lua
@@ -1,0 +1,233 @@
+local log = require("smart-motion.core.log")
+
+---@type SmartMotionCollectorModuleEntry
+local M = {}
+
+--- Treesitter node types that represent function/method calls across languages.
+local CALL_NODE_TYPES = {
+	"call_expression", -- JS/TS/Rust/Go
+	"call", -- Python
+	"function_call", -- Lua
+	"method_call_expression", -- Java
+	"invocation_expression", -- C#
+}
+
+--- Pattern-based scanner for function calls: name( ... )
+--- @param bufnr integer
+--- @param start_line integer 0-indexed
+--- @param end_line integer 0-indexed (inclusive)
+--- @return table[] List of function call data objects
+local function scan_calls_pattern(bufnr, start_line, end_line)
+	local results = {}
+
+	for line_num = start_line, end_line do
+		local line = vim.api.nvim_buf_get_lines(bufnr, line_num, line_num + 1, false)[1]
+		if line then
+			local pos = 1
+			while pos <= #line do
+				-- Match function_name( or obj.method( or obj:method(
+				local s, e, func_name = line:find("([%w_%.%:]+)%s*%(", pos)
+				if not s then
+					break
+				end
+
+				-- Find the matching close paren using stack
+				local paren_col = line:find("%(", e) or e
+				local depth = 1
+				local close_row = line_num
+				local close_col = nil
+
+				-- Search for closing paren starting from after the open paren
+				local search_col = paren_col + 1
+				local search_row = line_num
+				local all_lines = vim.api.nvim_buf_get_lines(bufnr, start_line, end_line + 1, false)
+
+				while search_row <= end_line and depth > 0 do
+					local search_line = all_lines[search_row - start_line + 1]
+					if search_line then
+						for c = search_col, #search_line do
+							local ch = search_line:sub(c, c)
+							if ch == "(" then
+								depth = depth + 1
+							elseif ch == ")" then
+								depth = depth - 1
+								if depth == 0 then
+									close_row = search_row
+									close_col = c - 1 -- 0-indexed
+									break
+								end
+							end
+						end
+					end
+					if depth > 0 then
+						search_row = search_row + 1
+						search_col = 1
+					end
+				end
+
+				if close_col then
+					local open_col_start = s - 1 -- 0-indexed, start of function name
+					local open_col_end = e -- exclusive, after the "("
+
+					-- Get content between parens
+					local content_lines = vim.api.nvim_buf_get_text(
+						bufnr,
+						line_num,
+						open_col_end,
+						close_row,
+						close_col,
+						{}
+					)
+					local content = table.concat(content_lines, "\n")
+
+					table.insert(results, {
+						open_pos = {
+							start = { row = line_num, col = open_col_start },
+							["end"] = { row = line_num, col = open_col_end },
+						},
+						close_pos = {
+							start = { row = close_row, col = close_col },
+							["end"] = { row = close_row, col = close_col + 1 },
+						},
+						pair_open = func_name .. "(",
+						pair_close = ")",
+						func_name = func_name,
+						content_text = content,
+						full_text = func_name .. "(" .. content .. ")",
+					})
+				end
+
+				pos = e + 1
+			end
+		end
+	end
+
+	return results
+end
+
+--- Collects function call sites in visible buffer.
+--- @return thread A coroutine generator yielding function call data objects
+function M.run()
+	return coroutine.create(function(ctx, cfg, motion_state)
+		local bufnr = ctx.bufnr
+
+		-- Determine visible range
+		local winid = ctx.winid or 0
+		local start_line = vim.fn.line("w0", winid) - 1
+		local end_line = vim.fn.line("w$", winid) - 1
+
+		-- Try treesitter first
+		local ts_results = nil
+		local ok, parser = pcall(vim.treesitter.get_parser, bufnr)
+		if ok and parser then
+			local trees = parser:parse()
+			if trees and trees[1] then
+				local root = trees[1]:root()
+				if not root:has_error() then
+					ts_results = {}
+					M._collect_ts_calls(root, bufnr, start_line, end_line, ts_results)
+				end
+			end
+		end
+
+		local results = ts_results and #ts_results > 0 and ts_results
+			or scan_calls_pattern(bufnr, start_line, end_line)
+
+		for _, result in ipairs(results) do
+			coroutine.yield(result)
+		end
+	end)
+end
+
+--- Recursively collects function call sites from treesitter nodes.
+--- @param node TSNode
+--- @param bufnr integer
+--- @param start_line integer
+--- @param end_line integer
+--- @param results table[]
+function M._collect_ts_calls(node, bufnr, start_line, end_line, results)
+	local node_type = node:type()
+	local is_call = false
+
+	for _, call_type in ipairs(CALL_NODE_TYPES) do
+		if node_type == call_type then
+			is_call = true
+			break
+		end
+	end
+
+	if is_call then
+		local nsr, nsc, ner, nec = node:range()
+
+		if nsr >= start_line and ner <= end_line then
+			-- Extract function name and argument positions
+			local func_name = nil
+			local args_node = nil
+
+			for child in node:iter_children() do
+				local child_type = child:type()
+				-- Function name (various node types across languages)
+				if child_type == "identifier"
+					or child_type == "field_expression"
+					or child_type == "member_expression"
+					or child_type == "method"
+					or child_type == "attribute"
+				then
+					func_name = vim.treesitter.get_node_text(child, bufnr)
+				end
+				-- Arguments
+				if child_type == "arguments"
+					or child_type == "argument_list"
+					or child_type == "call_body"
+				then
+					args_node = child
+				end
+			end
+
+			-- Fallback: use first child as name if not identified
+			if not func_name and node:child_count() > 0 then
+				local first = node:child(0)
+				if first then
+					func_name = vim.treesitter.get_node_text(first, bufnr)
+				end
+			end
+
+			if func_name and args_node then
+				local asr, asc, aer, aec = args_node:range()
+
+				-- open_pos: from function name start to after opening paren
+				-- close_pos: the closing paren
+				local content_lines = vim.api.nvim_buf_get_text(bufnr, asr, asc + 1, aer, aec - 1, {})
+				local content = table.concat(content_lines, "\n")
+
+				table.insert(results, {
+					open_pos = {
+						start = { row = nsr, col = nsc },
+						["end"] = { row = asr, col = asc + 1 }, -- after "("
+					},
+					close_pos = {
+						start = { row = aer, col = aec - 1 }, -- the ")"
+						["end"] = { row = aer, col = aec },
+					},
+					pair_open = func_name .. "(",
+					pair_close = ")",
+					func_name = func_name,
+					content_text = content,
+					full_text = vim.treesitter.get_node_text(node, bufnr),
+				})
+			end
+		end
+	end
+
+	-- Recurse into children
+	for child in node:iter_children() do
+		M._collect_ts_calls(child, bufnr, start_line, end_line, results)
+	end
+end
+
+M.metadata = {
+	label = "Function Calls Collector",
+	description = "Collects function call sites from the visible buffer",
+}
+
+return M

--- a/lua/smart-motion/collectors/init.lua
+++ b/lua/smart-motion/collectors/init.lua
@@ -6,6 +6,9 @@ local git_hunks = require("smart-motion.collectors.git_hunks")
 local quickfix = require("smart-motion.collectors.quickfix")
 local marks = require("smart-motion.collectors.marks")
 local patterns = require("smart-motion.collectors.patterns")
+local pairs_collector = require("smart-motion.collectors.pairs")
+local tags = require("smart-motion.collectors.tags")
+local function_calls = require("smart-motion.collectors.function_calls")
 
 ---@type SmartMotionRegistry<SmartMotionCollectorModuleEntry>
 local collectors = require("smart-motion.core.registry")("collectors")
@@ -20,6 +23,9 @@ collectors.register_many({
 	quickfix = quickfix,
 	marks = marks,
 	patterns = patterns,
+	pairs = pairs_collector,
+	tags = tags,
+	function_calls = function_calls,
 })
 
 return collectors

--- a/lua/smart-motion/collectors/pairs.lua
+++ b/lua/smart-motion/collectors/pairs.lua
@@ -1,0 +1,214 @@
+local log = require("smart-motion.core.log")
+local pair_defs = require("smart-motion.utils.pair_defs")
+
+---@type SmartMotionCollectorModuleEntry
+local M = {}
+
+--- Scans visible lines for matching delimiter pairs using a stack-based approach.
+--- @param bufnr integer
+--- @param start_line integer 0-indexed
+--- @param end_line integer 0-indexed (inclusive)
+--- @param open_char string
+--- @param close_char string
+--- @return table[] List of pair data objects
+local function scan_pairs_pattern(bufnr, start_line, end_line, open_char, close_char)
+	local results = {}
+	local is_symmetric = (open_char == close_char)
+
+	if is_symmetric then
+		-- For symmetric delimiters (quotes), find pairs on the same line
+		for line_num = start_line, end_line do
+			local line = vim.api.nvim_buf_get_lines(bufnr, line_num, line_num + 1, false)[1]
+			if line then
+				local positions = {}
+				local i = 1
+				while i <= #line do
+					local ch = line:sub(i, i)
+					-- Skip escaped delimiters
+					if i > 1 and line:sub(i - 1, i - 1) == "\\" then
+						i = i + 1
+						goto continue
+					end
+					if ch == open_char then
+						table.insert(positions, i - 1) -- 0-indexed col
+					end
+					i = i + 1
+					::continue::
+				end
+
+				-- Pair them up: 1st with 2nd, 3rd with 4th, etc.
+				for j = 1, #positions - 1, 2 do
+					local open_col = positions[j]
+					local close_col = positions[j + 1]
+					local content = line:sub(open_col + 2, close_col) -- between delimiters
+					table.insert(results, {
+						open_pos = {
+							start = { row = line_num, col = open_col },
+							["end"] = { row = line_num, col = open_col + #open_char },
+						},
+						close_pos = {
+							start = { row = line_num, col = close_col },
+							["end"] = { row = line_num, col = close_col + #close_char },
+						},
+						pair_open = open_char,
+						pair_close = close_char,
+						content_text = content,
+						full_text = open_char .. content .. close_char,
+					})
+				end
+			end
+		end
+	else
+		-- For asymmetric delimiters, use a stack-based scanner
+		local stack = {}
+
+		for line_num = start_line, end_line do
+			local line = vim.api.nvim_buf_get_lines(bufnr, line_num, line_num + 1, false)[1]
+			if line then
+				for col = 0, #line - 1 do
+					local ch = line:sub(col + 1, col + 1)
+					if ch == open_char then
+						table.insert(stack, { row = line_num, col = col })
+					elseif ch == close_char and #stack > 0 then
+						local open = table.remove(stack)
+						-- Get content between delimiters
+						local content_lines = vim.api.nvim_buf_get_text(
+							bufnr,
+							open.row,
+							open.col + #open_char,
+							line_num,
+							col,
+							{}
+						)
+						local content = table.concat(content_lines, "\n")
+						table.insert(results, {
+							open_pos = {
+								start = { row = open.row, col = open.col },
+								["end"] = { row = open.row, col = open.col + #open_char },
+							},
+							close_pos = {
+								start = { row = line_num, col = col },
+								["end"] = { row = line_num, col = col + #close_char },
+							},
+							pair_open = open_char,
+							pair_close = close_char,
+							content_text = content,
+							full_text = open_char .. content .. close_char,
+						})
+					end
+				end
+			end
+		end
+	end
+
+	return results
+end
+
+--- Collects matching delimiter pairs in visible buffer.
+--- Reads motion_state.pair_chars to know which pair to find.
+--- @return thread A coroutine generator yielding pair data objects
+function M.run()
+	return coroutine.create(function(ctx, cfg, motion_state)
+		local bufnr = ctx.bufnr
+		local pair_chars = motion_state.pair_chars
+
+		if not pair_chars or #pair_chars == 0 then
+			log.debug("Pairs collector: no pair_chars specified in motion_state")
+			return
+		end
+
+		-- Determine visible range
+		local winid = ctx.winid or 0
+		local start_line = vim.fn.line("w0", winid) - 1 -- 0-indexed
+		local end_line = vim.fn.line("w$", winid) - 1
+
+		for _, pair in ipairs(pair_chars) do
+			local open_char = pair[1]
+			local close_char = pair[2]
+
+			-- Try treesitter first for better accuracy, but fall back to
+			-- pattern scanning if the tree has errors (common while editing)
+			local ts_results = nil
+			local ok, parser = pcall(vim.treesitter.get_parser, bufnr)
+			if ok and parser then
+				local trees = parser:parse()
+				if trees and trees[1] then
+					local root = trees[1]:root()
+					if not root:has_error() then
+						ts_results = {}
+						M._collect_ts_pairs(root, bufnr, open_char, close_char, start_line, end_line, ts_results)
+					end
+				end
+			end
+
+			local results = ts_results and #ts_results > 0 and ts_results
+				or scan_pairs_pattern(bufnr, start_line, end_line, open_char, close_char)
+
+			for _, result in ipairs(results) do
+				coroutine.yield(result)
+			end
+		end
+	end)
+end
+
+--- Recursively collects delimiter pairs from treesitter nodes.
+--- Looks for nodes whose first/last children match the delimiter chars.
+--- @param node TSNode
+--- @param bufnr integer
+--- @param open_char string
+--- @param close_char string
+--- @param start_line integer
+--- @param end_line integer
+--- @param results table[]
+function M._collect_ts_pairs(node, bufnr, open_char, close_char, start_line, end_line, results)
+	local child_count = node:child_count()
+
+	if child_count >= 2 then
+		local first = node:child(0)
+		local last = node:child(child_count - 1)
+
+		if first and last then
+			local first_text = vim.treesitter.get_node_text(first, bufnr)
+			local last_text = vim.treesitter.get_node_text(last, bufnr)
+
+			if first_text == open_char and last_text == close_char then
+				local fsr, fsc, fer, fec = first:range()
+				local lsr, lsc, ler, lec = last:range()
+
+				-- Only include if within visible range
+				if fsr >= start_line and ler <= end_line then
+					-- Get content between delimiters
+					local content_lines = vim.api.nvim_buf_get_text(bufnr, fer, fec, lsr, lsc, {})
+					local content = table.concat(content_lines, "\n")
+
+					table.insert(results, {
+						open_pos = {
+							start = { row = fsr, col = fsc },
+							["end"] = { row = fer, col = fec },
+						},
+						close_pos = {
+							start = { row = lsr, col = lsc },
+							["end"] = { row = ler, col = lec },
+						},
+						pair_open = open_char,
+						pair_close = close_char,
+						content_text = content,
+						full_text = open_char .. content .. close_char,
+					})
+				end
+			end
+		end
+	end
+
+	-- Recurse into children
+	for child in node:iter_children() do
+		M._collect_ts_pairs(child, bufnr, open_char, close_char, start_line, end_line, results)
+	end
+end
+
+M.metadata = {
+	label = "Pairs Collector",
+	description = "Collects matching delimiter pairs from the visible buffer",
+}
+
+return M

--- a/lua/smart-motion/collectors/tags.lua
+++ b/lua/smart-motion/collectors/tags.lua
@@ -1,0 +1,232 @@
+local log = require("smart-motion.core.log")
+
+---@type SmartMotionCollectorModuleEntry
+local M = {}
+
+--- Pattern-based scanner for HTML/XML tag pairs in visible lines.
+--- @param bufnr integer
+--- @param start_line integer 0-indexed
+--- @param end_line integer 0-indexed (inclusive)
+--- @return table[] List of tag pair data objects
+local function scan_tags_pattern(bufnr, start_line, end_line)
+	local results = {}
+	local lines = vim.api.nvim_buf_get_lines(bufnr, start_line, end_line + 1, false)
+
+	-- First pass: collect all opening and closing tags with positions
+	local open_tags = {} -- { { name, row, col_start, col_end }, ... }
+	local close_tags = {} -- { { name, row, col_start, col_end }, ... }
+
+	for i, line in ipairs(lines) do
+		local row = start_line + i - 1
+
+		-- Find opening tags: <tagname ...> (not self-closing, not closing)
+		local pos = 1
+		while pos <= #line do
+			local s, e, tag_name = line:find("<([%w_%-%.]+)[^>]*>", pos)
+			if not s then
+				break
+			end
+			-- Skip closing tags and self-closing tags
+			local full = line:sub(s, e)
+			if not full:match("^</") and not full:match("/>$") then
+				table.insert(open_tags, {
+					name = tag_name,
+					row = row,
+					col_start = s - 1, -- 0-indexed
+					col_end = e, -- exclusive
+				})
+			end
+			pos = e + 1
+		end
+
+		-- Find closing tags: </tagname>
+		pos = 1
+		while pos <= #line do
+			local s, e, tag_name = line:find("</([%w_%-%.]+)%s*>", pos)
+			if not s then
+				break
+			end
+			table.insert(close_tags, {
+				name = tag_name,
+				row = row,
+				col_start = s - 1, -- 0-indexed
+				col_end = e, -- exclusive
+			})
+			pos = e + 1
+		end
+	end
+
+	-- Match open tags to close tags using stack-based matching
+	local stack = {}
+	-- Combine and sort all tags by position
+	local all_tags = {}
+	for _, t in ipairs(open_tags) do
+		table.insert(all_tags, { type = "open", data = t })
+	end
+	for _, t in ipairs(close_tags) do
+		table.insert(all_tags, { type = "close", data = t })
+	end
+	table.sort(all_tags, function(a, b)
+		if a.data.row ~= b.data.row then
+			return a.data.row < b.data.row
+		end
+		return a.data.col_start < b.data.col_start
+	end)
+
+	for _, tag in ipairs(all_tags) do
+		if tag.type == "open" then
+			table.insert(stack, tag.data)
+		elseif tag.type == "close" then
+			-- Find matching open tag (search stack from top)
+			for j = #stack, 1, -1 do
+				if stack[j].name == tag.data.name then
+					local open = table.remove(stack, j)
+					local close = tag.data
+					-- Get content between tags
+					local content_lines = vim.api.nvim_buf_get_text(
+						bufnr,
+						open.row,
+						open.col_end,
+						close.row,
+						close.col_start,
+						{}
+					)
+					local content = table.concat(content_lines, "\n")
+
+					table.insert(results, {
+						open_pos = {
+							start = { row = open.row, col = open.col_start },
+							["end"] = { row = open.row, col = open.col_end },
+						},
+						close_pos = {
+							start = { row = close.row, col = close.col_start },
+							["end"] = { row = close.row, col = close.col_end },
+						},
+						pair_open = "<" .. open.name .. ">",
+						pair_close = "</" .. close.name .. ">",
+						tag_name = open.name,
+						content_text = content,
+						full_text = "<" .. open.name .. ">" .. content .. "</" .. close.name .. ">",
+					})
+					break
+				end
+			end
+		end
+	end
+
+	return results
+end
+
+--- Collects matching HTML/XML tag pairs in visible buffer.
+--- @return thread A coroutine generator yielding tag pair data objects
+function M.run()
+	return coroutine.create(function(ctx, cfg, motion_state)
+		local bufnr = ctx.bufnr
+
+		-- Determine visible range
+		local winid = ctx.winid or 0
+		local start_line = vim.fn.line("w0", winid) - 1
+		local end_line = vim.fn.line("w$", winid) - 1
+
+		-- Try treesitter first for HTML/JSX/TSX files
+		local ts_results = nil
+		local ok, parser = pcall(vim.treesitter.get_parser, bufnr)
+		if ok and parser then
+			local trees = parser:parse()
+			if trees and trees[1] then
+				local root = trees[1]:root()
+				if not root:has_error() then
+					ts_results = {}
+					M._collect_ts_tags(root, bufnr, start_line, end_line, ts_results)
+				end
+			end
+		end
+
+		local results = ts_results and #ts_results > 0 and ts_results
+			or scan_tags_pattern(bufnr, start_line, end_line)
+
+		for _, result in ipairs(results) do
+			coroutine.yield(result)
+		end
+	end)
+end
+
+--- Recursively collects tag pairs from treesitter nodes.
+--- @param node TSNode
+--- @param bufnr integer
+--- @param start_line integer
+--- @param end_line integer
+--- @param results table[]
+function M._collect_ts_tags(node, bufnr, start_line, end_line, results)
+	local node_type = node:type()
+
+	-- HTML element, JSX element, etc.
+	local is_element = node_type == "element"
+		or node_type == "jsx_element"
+		or node_type == "tsx_element"
+
+	if is_element then
+		local open_tag = nil
+		local close_tag = nil
+
+		for child in node:iter_children() do
+			local child_type = child:type()
+			if child_type == "start_tag" or child_type == "jsx_opening_element" or child_type == "tsx_opening_element" then
+				open_tag = child
+			elseif child_type == "end_tag" or child_type == "jsx_closing_element" or child_type == "tsx_closing_element" then
+				close_tag = child
+			end
+		end
+
+		if open_tag and close_tag then
+			local osr, osc, oer, oec = open_tag:range()
+			local csr, csc, cer, cec = close_tag:range()
+
+			if osr >= start_line and cer <= end_line then
+				-- Extract tag name from the opening tag
+				local tag_name = nil
+				for child in open_tag:iter_children() do
+					if child:type() == "tag_name" or child:type() == "identifier" then
+						tag_name = vim.treesitter.get_node_text(child, bufnr)
+						break
+					end
+				end
+
+				if tag_name then
+					local content_lines = vim.api.nvim_buf_get_text(bufnr, oer, oec, csr, csc, {})
+					local content = table.concat(content_lines, "\n")
+					local open_text = vim.treesitter.get_node_text(open_tag, bufnr)
+					local close_text = vim.treesitter.get_node_text(close_tag, bufnr)
+
+					table.insert(results, {
+						open_pos = {
+							start = { row = osr, col = osc },
+							["end"] = { row = oer, col = oec },
+						},
+						close_pos = {
+							start = { row = csr, col = csc },
+							["end"] = { row = cer, col = cec },
+						},
+						pair_open = open_text,
+						pair_close = close_text,
+						tag_name = tag_name,
+						content_text = content,
+						full_text = open_text .. content .. close_text,
+					})
+				end
+			end
+		end
+	end
+
+	-- Recurse into children
+	for child in node:iter_children() do
+		M._collect_ts_tags(child, bufnr, start_line, end_line, results)
+	end
+end
+
+M.metadata = {
+	label = "Tags Collector",
+	description = "Collects matching HTML/XML tag pairs from the visible buffer",
+}
+
+return M

--- a/lua/smart-motion/config.lua
+++ b/lua/smart-motion/config.lua
@@ -40,6 +40,12 @@ M.defaults = {
 	selection_keys = {
 		["<CR>"] = "select_first",
 	},
+	expansion_keys = {
+		["+"] = "expand_forward",
+		["-"] = "expand_backward",
+		["<BS>"] = "shrink",
+	},
+	surround_pad = "opening",
 }
 
 ---@type SmartMotionConfig
@@ -229,6 +235,33 @@ function M.validate(user_config)
 	--
 	if config.history_max_age_days == nil or type(config.history_max_age_days) ~= "number" or config.history_max_age_days < 1 then
 		config.history_max_age_days = 30
+	end
+
+	--
+	-- Validate surround_pad
+	--
+	local valid_pad = { opening = true, closing = true }
+	if config.surround_pad ~= false and not valid_pad[config.surround_pad] then
+		config.surround_pad = "opening"
+	end
+
+	--
+	-- Validate expansion_keys
+	--
+	if config.expansion_keys ~= false then
+		if config.expansion_keys ~= nil and type(config.expansion_keys) ~= "table" then
+			config.expansion_keys = M.defaults.expansion_keys
+		end
+
+		if type(config.expansion_keys) == "table" then
+			local validated_exp = {}
+			for key, action in pairs(config.expansion_keys) do
+				if type(key) == "string" and type(action) == "string" then
+					validated_exp[key] = action
+				end
+			end
+			config.expansion_keys = validated_exp
+		end
 	end
 
 	--

--- a/lua/smart-motion/consts.lua
+++ b/lua/smart-motion/consts.lua
@@ -34,6 +34,7 @@ M.TARGET_TYPES = {
 	LINES = "lines",
 	SEARCH = "search",
 	TREESITTER = "treesitter",
+	PAIRS = "pairs",
 }
 
 ---@type table<string, TargetType>
@@ -44,6 +45,7 @@ M.TARGET_TYPES_BY_KEY = {
 }
 
 M.WORD_PATTERN = [[\k\+\|\%(\k\@!\S\)\+]]
+M.KEYWORD_PATTERN = [[\k\+]]
 M.BIG_WORD_PATTERN = [[[^ \t]\+]]
 
 ---@type table<string, SelectionMode>

--- a/lua/smart-motion/core/engine/exit.lua
+++ b/lua/smart-motion/core/engine/exit.lua
@@ -28,6 +28,11 @@ function M.run(ctx, cfg, motion_state, exit_type)
 		selection.wait_for_hint_selection(ctx, cfg, motion_state)
 	end
 
+	-- Expansion phase: after target selected, allow growing/shrinking the range
+	if motion_state.selected_jump_target and motion_state.expansion_enabled then
+		require("smart-motion.core.expansion").run(ctx, cfg, motion_state)
+	end
+
 	if motion_state.selected_jump_target then
 		if ctx.mode and ctx.mode:find("o") and not motion_state.is_textobject then
 			require("smart-motion.actions.jump").run(ctx, cfg, motion_state)

--- a/lua/smart-motion/core/engine/infer.lua
+++ b/lua/smart-motion/core/engine/infer.lua
@@ -3,27 +3,127 @@ local consts = require("smart-motion.consts")
 local module_loader = require("smart-motion.utils.module_loader")
 local targets = require("smart-motion.core.targets")
 local state = require("smart-motion.core.state")
-local utils = require("smart-motion.utils")
+local key_resolver = require("smart-motion.core.key_resolver")
 local log = require("smart-motion.core.log")
 
 local EXIT_TYPE = consts.EXIT_TYPE
+local RESOLVE_TYPE = key_resolver.RESOLVE_TYPE
 
 local M = {}
 
---- Non-blocking getchar with timeout. Returns the char or nil on timeout.
---- @param timeout_ms number
---- @return string|nil
-local function getchar_with_timeout(timeout_ms)
-	local result = nil
-	vim.wait(timeout_ms, function()
-		local c = vim.fn.getchar(1) -- non-blocking peek
-		if c ~= 0 then
-			result = type(c) == "number" and vim.fn.nr2char(c) or c
-			return true
+--- Apply a resolved textobject to the current motion_state.
+--- Copies pipeline components from the textobject and merges
+--- the appropriate motion_state overrides (inside/around/surround).
+--- @param motion_state SmartMotionMotionState
+--- @param result table Resolve result from key_resolver
+local function apply_textobject(motion_state, result)
+	local textobject = result.textobject
+	local motion = motion_state.motion
+
+	-- Copy pipeline components from textobject
+	if textobject.collector then motion.collector = textobject.collector end
+	if textobject.extractor then motion.extractor = textobject.extractor end
+	if textobject.filter then motion.filter = textobject.filter end
+	if textobject.visualizer then motion.visualizer = textobject.visualizer end
+	if textobject.modifier then motion.modifier = textobject.modifier end
+
+	-- Merge base motion_state from textobject
+	if textobject.metadata and textobject.metadata.motion_state then
+		for k, v in pairs(textobject.metadata.motion_state) do
+			motion_state[k] = v
 		end
-		return false
-	end, 10) -- poll every 10ms
-	return result
+	end
+
+	-- Merge the prefix-specific motion_state overrides (inside/around/surround)
+	local textobject_key = result.textobject_key
+	local overrides = textobject[textobject_key]
+	if not overrides then
+		-- No overrides for this key, try the default
+		local default_key = textobject.default or "around"
+		overrides = textobject[default_key]
+	end
+	if overrides then
+		for k, v in pairs(overrides) do
+			-- Pipeline overrides: swap collector/extractor for this prefix
+			if k == "_collector_override" then
+				motion.collector = v
+			elseif k == "_extractor_override" then
+				motion.extractor = v
+			else
+				motion_state[k] = v
+			end
+		end
+	end
+end
+
+--- Apply a resolved composable motion to the current motion_state.
+--- Copies pipeline components and conditionally copies action.
+--- @param motion_state SmartMotionMotionState
+--- @param result table Resolve result from key_resolver
+local function apply_composable(motion_state, result)
+	local target_motion = result.composable
+	local motion = motion_state.motion
+
+	if target_motion.extractor then motion.extractor = target_motion.extractor end
+	if target_motion.filter then motion.filter = target_motion.filter end
+	if target_motion.visualizer then motion.visualizer = target_motion.visualizer end
+	if target_motion.collector then motion.collector = target_motion.collector end
+
+	-- Only copy action from composable motions that explicitly request it
+	-- (e.g. surround motions). Standard composable motions (w, b, e) have
+	-- action = "jump_centered" which is their standalone default and should
+	-- NOT override the operator's action (d→delete_jump, y→yank_jump, etc.).
+	if target_motion.override_action and target_motion.action then
+		motion.action = target_motion.action
+	end
+
+	-- Merge target motion's metadata into motion_state
+	if target_motion.metadata and target_motion.metadata.motion_state then
+		for k, v in pairs(target_motion.metadata.motion_state) do
+			motion_state[k] = v
+		end
+	end
+end
+
+--- Handle the fallback case when no extractor was resolved.
+--- Checks for line actions (dd, yy), treesitter search (R),
+--- and feeds remaining keys back to vim for native handling.
+--- @param ctx SmartMotionContext
+--- @param cfg SmartMotionConfig
+--- @param motion_state SmartMotionMotionState
+--- @param motion_key string
+--- @param modules table
+local function handle_no_extractor(ctx, cfg, motion_state, motion_key, modules)
+	-- Line action: operator key repeated (dd, yy, cc)
+	if motion_key == motion_state.motion.action_key then
+		motion_state.target_type = "lines"
+
+		local action_name = modules.action.name:gsub("_jump$", "")
+		local line_action =
+			module_loader.get_module_by_name(ctx, cfg, motion_state, "actions", action_name .. "_line")
+
+		if line_action and line_action.run then
+			motion_state.selected_jump_target = targets.get_target_under_cursor(ctx, cfg, motion_state)
+
+			if motion_state.selected_jump_target then
+				line_action.run(ctx, cfg, motion_state)
+				exit.throw(EXIT_TYPE.EARLY_EXIT)
+			end
+		end
+	end
+
+	-- Special case: R (treesitter search) called from operator context (yR, dR, cR).
+	if motion_key == "R" then
+		require("smart-motion.actions.treesitter_search").run(nil, motion_state.motion.action_key)
+		exit.throw(EXIT_TYPE.EARLY_EXIT)
+	end
+
+	-- Feed trigger key with noremap to get native operator behavior (avoids recursion),
+	-- but feed the motion key with remap so user/plugin "o" mode keymaps fire.
+	local resolved_trigger = vim.api.nvim_replace_termcodes(motion_state.motion.trigger_key, true, false, true)
+	vim.api.nvim_feedkeys(resolved_trigger, "n", false)
+	vim.api.nvim_feedkeys(motion_key, "m", false)
+	exit.throw(EXIT_TYPE.EARLY_EXIT)
 end
 
 function M.run(ctx, cfg, motion_state)
@@ -31,118 +131,52 @@ function M.run(ctx, cfg, motion_state)
 		return
 	end
 
-	local ok, raw_key = exit.safe(pcall(vim.fn.getchar))
-	exit.throw_if(not ok, EXIT_TYPE.EARLY_EXIT)
+	-- Resolve key sequence: textobject (i/a prefix), composable, or fallback
+	local result = key_resolver.resolve(motion_state)
+	exit.throw_if(not result, EXIT_TYPE.EARLY_EXIT)
 
-	local first_char = type(raw_key) == "number" and vim.fn.nr2char(raw_key) or raw_key
-	exit.throw_if(first_char == "\027", EXIT_TYPE.EARLY_EXIT)
-
-	-- Multi-char resolution: check for longer composable motions after reading first char.
-	-- If the current char is both a composable match AND a prefix of longer composable keys,
-	-- wait up to timeoutlen for more input.
-	local motions_reg = require("smart-motion.motions")
-	local motion_key = first_char
-	local target_motion = motions_reg.get_composable_by_key(motion_key)
-
-	while motions_reg.has_composable_with_prefix(motion_key) do
-		local next_char = getchar_with_timeout(vim.o.timeoutlen)
-		if not next_char then break end -- timeout, use current match
-		if next_char == "\027" then break end -- ESC cancels, use current match
-
-		local longer_key = motion_key .. next_char
-		local longer_match = motions_reg.get_composable_by_key(longer_key)
-
-		if longer_match or motions_reg.has_composable_with_prefix(longer_key) then
-			motion_key = longer_key
-			target_motion = longer_match or target_motion
-		else
-			-- Extra char doesn't extend any composable — push it back
-			vim.api.nvim_feedkeys(next_char, "t", false)
-			break
-		end
-	end
-
+	local motion_key = result.motion_key
 	motion_state.motion_key = motion_key
 	motion_state.target_type = consts.TARGET_TYPES_BY_KEY[motion_key]
 
-	-- Motion-based inference: look up a composable motion by motion_key.
-	-- This allows any registered composable motion (w, b, e, j, k, s, f, etc.)
-	-- to automatically work as a target for operators (d, y, c, p).
-	-- If multi-char resolution already found a composable, use it directly.
-	if not target_motion then
-		target_motion = motions_reg.get_by_key(motion_key)
-	end
-
-	if target_motion and target_motion.composable then
-		local motion = motion_state.motion
-		if target_motion.extractor then motion.extractor = target_motion.extractor end
-		if target_motion.filter then motion.filter = target_motion.filter end
-		if target_motion.visualizer then motion.visualizer = target_motion.visualizer end
-		if target_motion.collector then motion.collector = target_motion.collector end
-
-		-- Merge target motion's metadata into motion_state
-		if target_motion.metadata and target_motion.metadata.motion_state then
-			for k, v in pairs(target_motion.metadata.motion_state) do
-				motion_state[k] = v
-			end
+	if result.type == RESOLVE_TYPE.TEXTOBJECT then
+		apply_textobject(motion_state, result)
+	elseif result.type == RESOLVE_TYPE.COMPOSABLE then
+		apply_composable(motion_state, result)
+		-- Carry textobject_key from i/a prefix if present (e.g. ysaw → around + w composable)
+		if result.textobject_key then
+			motion_state.textobject_key = result.textobject_key
 		end
-	end
-
-	-- Only request extractor if a composable motion populated it; otherwise the
-	-- fallback at line 103+ handles non-composable keys (dd, di, da, etc.) and
-	-- requesting it here would log a spurious "extractor 'default' not found" error.
-	local infer_keys = { "action", "visualizer", "filter" }
-	if motion_state.motion.extractor then
-		table.insert(infer_keys, 1, "extractor")
-	end
-	local modules = module_loader.get_modules(ctx, cfg, motion_state, infer_keys)
-
-	-- Merge inferred module metadata into motion_state (setup.run merged metadata for the
-	-- original motion, but infer may have overridden extractor/visualizer/filter/action)
-	for _, module in pairs(modules) do
-		if state.module_has_motion_state(module) then
-			for k, v in pairs(module.metadata.motion_state) do
-				motion_state[k] = v
-			end
-		end
-	end
-
-	if not modules.extractor or not modules.extractor.run then
-		if motion_key == motion_state.motion.action_key then
-			motion_state.target_type = "lines"
-
-			-- NOTE: We might need to set motion_state here if actions ever need to set it
-			-- Strip _jump suffix so delete_jump → delete_line, yank_jump → yank_line, etc.
-			local action_name = modules.action.name:gsub("_jump$", "")
-			local line_action =
-				module_loader.get_module_by_name(ctx, cfg, motion_state, "actions", action_name .. "_line")
-
-			if line_action and line_action.run then
-				motion_state.selected_jump_target = targets.get_target_under_cursor(ctx, cfg, motion_state)
-
-				if motion_state.selected_jump_target then
-					line_action.run(ctx, cfg, motion_state)
-					exit.throw(EXIT_TYPE.EARLY_EXIT)
-				end
-			end
-		end
-
-		-- Special case: R (treesitter search) called from operator context (yR, dR, cR).
-		-- Call treesitter_search directly with the operator instead of feeding keys
-		-- through operator-pending mode, which has timing issues with vim.schedule.
-		if motion_key == "R" then
-			require("smart-motion.actions.treesitter_search").run(nil, motion_state.motion.action_key)
-			exit.throw(EXIT_TYPE.EARLY_EXIT)
-		end
-
-		-- Feed trigger key with noremap to get native operator behavior (avoids recursion),
-		-- but feed the motion key with remap so user/plugin "o" mode keymaps fire (e.g. R).
+	elseif result.type == RESOLVE_TYPE.FALLBACK then
+		-- No composable or textobject found — feed back to vim
 		local resolved_trigger = vim.api.nvim_replace_termcodes(motion_state.motion.trigger_key, true, false, true)
 		vim.api.nvim_feedkeys(resolved_trigger, "n", false)
 		vim.api.nvim_feedkeys(motion_key, "m", false)
 		exit.throw(EXIT_TYPE.EARLY_EXIT)
 	end
 
+	-- Load modules with updated pipeline config
+	local infer_keys = { "action", "visualizer", "filter" }
+	if motion_state.motion.extractor then
+		table.insert(infer_keys, 1, "extractor")
+	end
+	local modules = module_loader.get_modules(ctx, cfg, motion_state, infer_keys)
+
+	-- Merge inferred module metadata into motion_state (defaults only —
+	-- don't overwrite values already set by the operator/motion config)
+	for _, module in pairs(modules) do
+		if state.module_has_motion_state(module) then
+			for k, v in pairs(module.metadata.motion_state) do
+				if motion_state[k] == nil then
+					motion_state[k] = v
+				end
+			end
+		end
+	end
+
+	if not modules.extractor or not modules.extractor.run then
+		handle_no_extractor(ctx, cfg, motion_state, motion_key, modules)
+	end
 end
 
 return M

--- a/lua/smart-motion/core/engine/init.lua
+++ b/lua/smart-motion/core/engine/init.lua
@@ -42,4 +42,28 @@ function M.run(trigger_key, opts)
 	utils.reset_motion(ctx, cfg, motion_state)
 end
 
+--- Run the engine with a textobject config directly (no registry lookup).
+--- Used by i/a keymaps in visual and operator-pending modes.
+--- @param textobject SmartMotionTextobjectEntry
+--- @param textobject_key string "inside" or "around"
+function M.run_textobject(textobject, textobject_key)
+	local ctx, cfg, motion_state
+
+	local exit_type = exit_event.wrap(function()
+		ctx, cfg, motion_state = setup.run_with_textobject(textobject, textobject_key)
+
+		if flow_state.evaluate_flow_at_motion_start() then
+			pipeline.run(ctx, cfg, motion_state)
+			exit_event.throw_if(motion_state.selected_jump_target, EXIT_TYPE.AUTO_SELECT)
+		end
+
+		highlight.dim_background(ctx, cfg, motion_state)
+
+		loop.run(ctx, cfg, motion_state)
+	end)
+
+	handle_exit.run(ctx, cfg, motion_state, exit_type)
+	utils.reset_motion(ctx, cfg, motion_state)
+end
+
 return M

--- a/lua/smart-motion/core/engine/setup.lua
+++ b/lua/smart-motion/core/engine/setup.lua
@@ -53,4 +53,60 @@ function M.run(trigger_key)
 	return ctx, cfg, motion_state
 end
 
+--- Set up engine context from a textobject entry (no registry lookup).
+--- Used by i/a keymaps in visual and operator-pending modes.
+--- @param textobject SmartMotionTextobjectEntry
+--- @param textobject_key string "inside" or "around"
+function M.run_with_textobject(textobject, textobject_key)
+	local ctx, cfg, motion_state = utils.prepare_motion()
+	exit.throw_if(not ctx or not cfg or not motion_state, EXIT_TYPE.EARLY_EXIT)
+
+	-- Build a motion entry from the textobject
+	local motion = {
+		name = textobject_key .. "_" .. (textobject.key or "textobject"),
+		trigger_key = textobject_key .. (textobject.key or ""),
+		collector = textobject.collector,
+		extractor = textobject.extractor,
+		modifier = textobject.modifier or "weight_distance",
+		filter = textobject.filter or "filter_visible",
+		visualizer = textobject.visualizer or "hint_start",
+		action = textobject.action or "textobject_select",
+		metadata = vim.deepcopy(textobject.metadata or {}),
+	}
+
+	motion_state.motion = motion
+	motion_state.motion_key = motion.trigger_key
+
+	-- Load modules
+	local modules = module_loader.get_modules(ctx, cfg, motion_state)
+	motion_state = state.merge_motion_state(motion_state, motion, modules)
+
+	-- Merge base motion_state from textobject
+	if textobject.metadata and textobject.metadata.motion_state then
+		for k, v in pairs(textobject.metadata.motion_state) do
+			motion_state[k] = v
+		end
+	end
+
+	-- Merge prefix-specific overrides (inside/around)
+	local overrides = textobject[textobject_key]
+	if not overrides then
+		overrides = textobject[textobject.default or "around"]
+	end
+	if overrides then
+		for k, v in pairs(overrides) do
+			-- Pipeline overrides: swap collector/extractor for this prefix
+			if k == "_collector_override" then
+				motion.collector = v
+			elseif k == "_extractor_override" then
+				motion.extractor = v
+			else
+				motion_state[k] = v
+			end
+		end
+	end
+
+	return ctx, cfg, motion_state
+end
+
 return M

--- a/lua/smart-motion/core/expansion.lua
+++ b/lua/smart-motion/core/expansion.lua
@@ -1,0 +1,273 @@
+local consts = require("smart-motion.consts")
+local highlight = require("smart-motion.core.highlight")
+local flow_state = require("smart-motion.core.flow_state")
+local log = require("smart-motion.core.log")
+
+local M = {}
+
+--- Compare two positions (row, col). Returns -1, 0, or 1.
+local function compare_pos(a_row, a_col, b_row, b_col)
+	if a_row < b_row then return -1 end
+	if a_row > b_row then return 1 end
+	if a_col < b_col then return -1 end
+	if a_col > b_col then return 1 end
+	return 0
+end
+
+--- Sort targets by buffer position (row, then col).
+--- Returns a new sorted list and a mapping from sorted index to original.
+--- @param jump_targets table[]
+--- @return table[] sorted_targets
+local function sort_by_position(jump_targets)
+	local sorted = {}
+	for i, t in ipairs(jump_targets) do
+		sorted[i] = t
+	end
+	table.sort(sorted, function(a, b)
+		local cmp = compare_pos(a.start_pos.row, a.start_pos.col, b.start_pos.row, b.start_pos.col)
+		return cmp < 0
+	end)
+	return sorted
+end
+
+--- Find the index of the selected target in a sorted target list.
+--- @param sorted_targets table[]
+--- @param selected table
+--- @return integer|nil
+local function find_anchor_index(sorted_targets, selected)
+	for i, target in ipairs(sorted_targets) do
+		if target.start_pos.row == selected.start_pos.row
+			and target.start_pos.col == selected.start_pos.col
+			and target.end_pos.row == selected.end_pos.row
+			and target.end_pos.col == selected.end_pos.col
+		then
+			return i
+		end
+	end
+	return nil
+end
+
+--- Highlight the expansion range between first and last target.
+--- @param bufnr integer
+--- @param first table Target with start_pos
+--- @param last table Target with end_pos
+--- @return integer extmark_id
+local function highlight_range(bufnr, first, last)
+	return vim.api.nvim_buf_set_extmark(bufnr, consts.ns_id, first.start_pos.row, first.start_pos.col, {
+		end_row = last.end_pos.row,
+		end_col = last.end_pos.col,
+		hl_group = "SmartMotionSelected",
+	})
+end
+
+--- Show dim +/- hints on the spatially adjacent targets.
+--- @param bufnr integer
+--- @param sorted_targets table[] Targets sorted by buffer position
+--- @param anchor integer Current anchor index in sorted list
+--- @param forward_extent integer How many targets expanded forward
+--- @param backward_extent integer How many targets expanded backward
+--- @return integer[] extmark_ids
+local function show_expansion_hints(bufnr, sorted_targets, anchor, forward_extent, backward_extent)
+	local ids = {}
+
+	-- Show "+" on the next target forward in buffer position
+	local next_idx = anchor + forward_extent + 1
+	if next_idx <= #sorted_targets then
+		local target = sorted_targets[next_idx]
+		ids[#ids + 1] = vim.api.nvim_buf_set_extmark(bufnr, consts.ns_id, target.start_pos.row, target.start_pos.col, {
+			virt_text = { { "+", "SmartMotionHintDim" } },
+			virt_text_pos = "overlay",
+			hl_mode = "combine",
+		})
+	end
+
+	-- Show "-" on the previous target backward in buffer position
+	local prev_idx = anchor - backward_extent - 1
+	if prev_idx >= 1 then
+		local target = sorted_targets[prev_idx]
+		ids[#ids + 1] = vim.api.nvim_buf_set_extmark(bufnr, consts.ns_id, target.start_pos.row, target.start_pos.col, {
+			virt_text = { { "-", "SmartMotionHintDim" } },
+			virt_text_pos = "overlay",
+			hl_mode = "combine",
+		})
+	end
+
+	-- Show "⌫" after the expanded range when there's something to undo
+	if forward_extent > 0 or backward_extent > 0 then
+		local last_target = sorted_targets[anchor + forward_extent]
+		ids[#ids + 1] = vim.api.nvim_buf_set_extmark(bufnr, consts.ns_id, last_target.end_pos.row, last_target.end_pos.col, {
+			virt_text = { { " ⌫", "SmartMotionHintDim" } },
+			virt_text_pos = "inline",
+			hl_mode = "combine",
+		})
+	end
+
+	return ids
+end
+
+--- Clear expansion hint extmarks.
+--- @param bufnr integer
+--- @param ids integer[]
+local function clear_expansion_hints(bufnr, ids)
+	for _, id in ipairs(ids) do
+		vim.api.nvim_buf_del_extmark(bufnr, consts.ns_id, id)
+	end
+end
+
+--- Synthesize a merged target spanning from first to last target.
+--- @param bufnr integer
+--- @param first table First target in range
+--- @param last table Last target in range
+--- @param original table The originally selected target (for metadata)
+--- @return table Merged target
+local function synthesize_target(bufnr, first, last, original)
+	local lines = vim.api.nvim_buf_get_text(
+		bufnr,
+		first.start_pos.row,
+		first.start_pos.col,
+		last.end_pos.row,
+		last.end_pos.col,
+		{}
+	)
+
+	return {
+		start_pos = { row = first.start_pos.row, col = first.start_pos.col },
+		end_pos = { row = last.end_pos.row, col = last.end_pos.col },
+		text = table.concat(lines, "\n"),
+		type = original.type,
+		metadata = original.metadata,
+	}
+end
+
+--- Run the interactive expansion loop.
+--- After a target is selected, allows the user to expand/shrink the range
+--- using +/- keys before the action's second step (e.g., typing a delimiter).
+---
+--- Any key that isn't +/-/BS/ESC is treated as an implicit confirm and is
+--- fed back to the input queue so the action receives it (e.g., the delimiter
+--- character for surround_add).
+---
+--- @param ctx SmartMotionContext
+--- @param cfg SmartMotionConfig
+--- @param motion_state SmartMotionMotionState
+function M.run(ctx, cfg, motion_state)
+	if not motion_state.expansion_enabled then
+		return
+	end
+
+	local selected = motion_state.selected_jump_target
+	if not selected then
+		return
+	end
+
+	local jump_targets = motion_state.jump_targets
+	if not jump_targets or #jump_targets < 2 then
+		return
+	end
+
+	-- Sort targets by buffer position so +/- expand spatially
+	local sorted = sort_by_position(jump_targets)
+
+	local anchor = find_anchor_index(sorted, selected)
+	if not anchor then
+		return
+	end
+
+	local expansion_keys = cfg.expansion_keys
+	if not expansion_keys then
+		return
+	end
+
+	-- Pause flow state so the timer doesn't expire during expansion
+	flow_state.pause_flow()
+
+	-- Clear hint labels and show initial selection
+	highlight.clear(ctx, cfg, motion_state)
+
+	local bufnr = (selected.metadata and selected.metadata.bufnr) or ctx.bufnr
+	local forward_extent = 0
+	local backward_extent = 0
+	local expansion_history = {}
+
+	-- Show initial highlight + expansion hints
+	local hl_id = highlight_range(bufnr, selected, selected)
+	local hint_ids = show_expansion_hints(bufnr, sorted, anchor, forward_extent, backward_extent)
+	vim.cmd("redraw")
+
+	while true do
+		local ok, char = pcall(vim.fn.getcharstr)
+		if not ok then
+			-- Error (e.g., Ctrl-C) — cancel
+			motion_state.selected_jump_target = nil
+			vim.api.nvim_buf_del_extmark(bufnr, consts.ns_id, hl_id)
+			clear_expansion_hints(bufnr, hint_ids)
+			flow_state.resume_flow()
+			return
+		end
+
+		-- Check expansion keys (check keytrans for special keys like <BS>)
+		local key_name = vim.fn.keytrans(char)
+		local action = expansion_keys[key_name] or expansion_keys[char]
+
+		if action == "expand_forward" then
+			if anchor + forward_extent < #sorted then
+				forward_extent = forward_extent + 1
+				table.insert(expansion_history, "forward")
+			end
+		elseif action == "expand_backward" then
+			if anchor - backward_extent > 1 then
+				backward_extent = backward_extent + 1
+				table.insert(expansion_history, "backward")
+			end
+		elseif action == "shrink" then
+			if #expansion_history > 0 then
+				local last_dir = table.remove(expansion_history)
+				if last_dir == "forward" then
+					forward_extent = forward_extent - 1
+				else
+					backward_extent = backward_extent - 1
+				end
+			end
+		else
+			-- ESC cancels
+			if char == "\027" or char == "" then
+				motion_state.selected_jump_target = nil
+				vim.api.nvim_buf_del_extmark(bufnr, consts.ns_id, hl_id)
+				clear_expansion_hints(bufnr, hint_ids)
+				flow_state.resume_flow()
+				return
+			end
+
+			-- Any other key = implicit confirm. Feed the key back so the
+			-- action receives it (e.g., the delimiter char for surround_add).
+			vim.api.nvim_feedkeys(char, "t", false)
+			break
+		end
+
+		-- Re-render the range highlight and expansion hints
+		vim.api.nvim_buf_del_extmark(bufnr, consts.ns_id, hl_id)
+		clear_expansion_hints(bufnr, hint_ids)
+
+		local range_first = sorted[anchor - backward_extent]
+		local range_last = sorted[anchor + forward_extent]
+		hl_id = highlight_range(bufnr, range_first, range_last)
+		hint_ids = show_expansion_hints(bufnr, sorted, anchor, forward_extent, backward_extent)
+		vim.cmd("redraw")
+	end
+
+	-- Clean up highlights
+	vim.api.nvim_buf_del_extmark(bufnr, consts.ns_id, hl_id)
+	clear_expansion_hints(bufnr, hint_ids)
+
+	-- Synthesize merged target if range was expanded
+	if forward_extent > 0 or backward_extent > 0 then
+		local range_first = sorted[anchor - backward_extent]
+		local range_last = sorted[anchor + forward_extent]
+		motion_state.selected_jump_target = synthesize_target(bufnr, range_first, range_last, selected)
+		motion_state.is_expanded_range = true
+	end
+
+	flow_state.resume_flow()
+end
+
+return M

--- a/lua/smart-motion/core/key_resolver.lua
+++ b/lua/smart-motion/core/key_resolver.lua
@@ -1,0 +1,193 @@
+local log = require("smart-motion.core.log")
+
+local M = {}
+
+--- Resolution result types
+M.RESOLVE_TYPE = {
+	TEXTOBJECT = "textobject",
+	COMPOSABLE = "composable",
+	FALLBACK = "fallback",
+}
+
+--- Non-blocking getchar with timeout. Returns the char or nil on timeout.
+--- @param timeout_ms number
+--- @return string|nil
+local function getchar_with_timeout(timeout_ms)
+	local result = nil
+	vim.wait(timeout_ms, function()
+		local c = vim.fn.getchar(1) -- non-blocking peek
+		if c ~= 0 then
+			result = type(c) == "number" and vim.fn.nr2char(c) or c
+			return true
+		end
+		return false
+	end, 10) -- poll every 10ms
+	return result
+end
+
+--- Read a single blocking char from user input.
+--- @return string|nil char, boolean ok
+local function read_char()
+	local ok, raw = pcall(vim.fn.getchar)
+	if not ok then
+		return nil, false
+	end
+	local char = type(raw) == "number" and vim.fn.nr2char(raw) or raw
+	return char, true
+end
+
+--- Try to resolve the first char as a textobject prefix (i/a).
+--- Reads the next char (blocking) and checks the textobject registry.
+--- @param prefix_char string "i" or "a"
+--- @param motions_reg table
+--- @return table|nil Resolve result, or nil if not a registered textobject
+local function try_textobject_prefix(prefix_char, motions_reg)
+	local target_char, ok = read_char()
+	if not ok or not target_char then
+		return nil
+	end
+	if target_char == "\027" then
+		return nil
+	end -- ESC
+
+	local textobject = motions_reg.get_textobject(target_char)
+	if textobject then
+		return {
+			type = M.RESOLVE_TYPE.TEXTOBJECT,
+			motion_key = target_char,
+			textobject_key = prefix_char == "i" and "inside" or "around",
+			textobject = textobject,
+		}
+	end
+
+	-- Not a registered textobject — return as fallback so infer can feed
+	-- the full sequence (e.g. "iG") back to vim for native handling.
+	return {
+		type = M.RESOLVE_TYPE.FALLBACK,
+		motion_key = prefix_char .. target_char,
+		target_char = target_char,
+	}
+end
+
+--- Try to resolve the first char as a textobject target directly.
+--- Used when the operator pre-sets textobject_key (e.g., ds/cs set "surround").
+--- @param char string
+--- @param textobject_key string
+--- @param motions_reg table
+--- @return table|nil Resolve result, or nil if not a registered textobject
+local function try_direct_textobject(char, textobject_key, motions_reg)
+	local textobject = motions_reg.get_textobject(char)
+	if textobject then
+		return {
+			type = M.RESOLVE_TYPE.TEXTOBJECT,
+			motion_key = char,
+			textobject_key = textobject_key,
+			textobject = textobject,
+		}
+	end
+	return nil
+end
+
+--- Resolve a composable motion using multi-char resolution with timeoutlen.
+--- @param first_char string
+--- @param motions_reg table
+--- @return table Resolve result (composable or fallback)
+local function resolve_composable(first_char, motions_reg)
+	local motion_key = first_char
+	local target_motion = motions_reg.get_composable_by_key(motion_key)
+
+	while motions_reg.has_composable_with_prefix(motion_key) do
+		local next_char = getchar_with_timeout(vim.o.timeoutlen)
+		if not next_char then
+			break
+		end -- timeout, use current match
+		if next_char == "\027" then
+			break
+		end -- ESC, use current match
+
+		local longer_key = motion_key .. next_char
+		local longer_match = motions_reg.get_composable_by_key(longer_key)
+
+		if longer_match or motions_reg.has_composable_with_prefix(longer_key) then
+			motion_key = longer_key
+			target_motion = longer_match or target_motion
+		else
+			-- Extra char doesn't extend any composable — push it back
+			vim.api.nvim_feedkeys(next_char, "t", false)
+			break
+		end
+	end
+
+	if target_motion then
+		return {
+			type = M.RESOLVE_TYPE.COMPOSABLE,
+			motion_key = motion_key,
+			composable = target_motion,
+		}
+	end
+
+	return {
+		type = M.RESOLVE_TYPE.FALLBACK,
+		motion_key = motion_key,
+	}
+end
+
+--- Resolve the key sequence after an operator in infer context.
+---
+--- Resolution priority:
+---   1. If motion_state.textobject_key is pre-set (ds/cs operators), look up
+---      first char directly in textobject registry.
+---   2. If first char is "i" or "a", read next char and look up in textobject
+---      registry. If not found, return fallback for native vim handling.
+---   3. Otherwise, resolve as composable motion using multi-char resolution
+---      with timeoutlen.
+---
+--- @param motion_state SmartMotionMotionState
+--- @return table|nil result with fields: type, motion_key, textobject_key?, textobject?, composable?
+function M.resolve(motion_state)
+	local motions_reg = require("smart-motion.motions")
+
+	local first_char, ok = read_char()
+	if not ok or not first_char then
+		return nil
+	end
+	if first_char == "\027" then
+		return nil
+	end -- ESC cancels
+
+	-- Priority 1: Operator pre-set textobject_key (ds/cs operators)
+	if motion_state.textobject_key then
+		local result = try_direct_textobject(first_char, motion_state.textobject_key, motions_reg)
+		if result then
+			return result
+		end
+		-- Not a textobject — fall through to composable/fallback
+	end
+
+	-- Priority 2: i/a textobject prefix (only if operator hasn't pre-set textobject_key)
+	if not motion_state.textobject_key and (first_char == "i" or first_char == "a") then
+		local result = try_textobject_prefix(first_char, motions_reg)
+		if not result then
+			return nil -- ESC/error
+		end
+
+		if result.type == M.RESOLVE_TYPE.TEXTOBJECT then
+			return result
+		end
+
+		-- Not a textobject. For standard operators (d/y/c), fall back to native vim.
+		-- For operators that opt in (e.g. ys), try composable resolution instead.
+		if motion_state.ia_resolve_composable and result.target_char then
+			local composable_result = resolve_composable(result.target_char, motions_reg)
+			composable_result.textobject_key = first_char == "i" and "inside" or "around"
+			return composable_result
+		end
+
+		return result
+	end
+
+	-- Priority 3: Composable motion resolution
+	return resolve_composable(first_char, motions_reg)
+end
+
+return M

--- a/lua/smart-motion/core/textobject_keymaps.lua
+++ b/lua/smart-motion/core/textobject_keymaps.lua
@@ -1,0 +1,51 @@
+local log = require("smart-motion.core.log")
+
+local M = {}
+
+local registered = false
+
+--- Register i and a keymaps in visual and operator-pending modes.
+--- These keymaps read the next char, look up the textobject registry,
+--- and run the smart-motion pipeline if a textobject is found.
+--- If not found, falls back to native vim text object behavior.
+---
+--- Only registers once — safe to call multiple times.
+function M.setup()
+	if registered then
+		return
+	end
+	registered = true
+
+	for _, prefix in ipairs({ "i", "a" }) do
+		local textobject_key = prefix == "i" and "inside" or "around"
+
+		vim.keymap.set({ "x", "o" }, prefix, function()
+			local ok, raw = pcall(vim.fn.getchar)
+			if not ok then
+				return
+			end
+			local char = type(raw) == "number" and vim.fn.nr2char(raw) or raw
+			if char == "\027" then
+				return
+			end -- ESC
+
+			local motions_reg = require("smart-motion.motions")
+			local textobject = motions_reg.get_textobject(char)
+
+			if textobject then
+				require("smart-motion.core.engine").run_textobject(textobject, textobject_key)
+			else
+				-- Not a registered textobject — feed back to vim for native handling.
+				-- Use noremap so we don't recurse into this handler.
+				local keys = vim.api.nvim_replace_termcodes(prefix .. char, true, false, true)
+				vim.api.nvim_feedkeys(keys, "n", false)
+			end
+		end, {
+			desc = "Smart-motion " .. textobject_key .. " text object",
+			noremap = true,
+			silent = true,
+		})
+	end
+end
+
+return M

--- a/lua/smart-motion/extractors/README.md
+++ b/lua/smart-motion/extractors/README.md
@@ -44,6 +44,12 @@ The `pass_through` extractor returns collector data unchanged. This is used when
 
 ---
 
+## Example: `pairs.lua` (Extracting Pair Targets)
+
+Extracts pair targets with inside/around/surround scoping based on `pair_scope` in `motion_state`.
+
+---
+
 ## When to Use an Extractor?
 
 | Use Case | Example Extractor |
@@ -56,3 +62,4 @@ The `pass_through` extractor returns collector data unchanged. This is used when
 | Live incremental search (literal) | `live_search` |
 | Fuzzy incremental search | `fuzzy_search` |
 | Passing pre-formed targets through | `pass_through` |
+| Extracting pair targets (inside/around/surround) | `pairs` |

--- a/lua/smart-motion/extractors/init.lua
+++ b/lua/smart-motion/extractors/init.lua
@@ -5,6 +5,7 @@ local text_search = require("smart-motion.extractors.text_search")
 local live_search = require("smart-motion.extractors.live_search")
 local fuzzy_search = require("smart-motion.extractors.fuzzy_search")
 local pass_through = require("smart-motion.extractors.pass_through")
+local pairs_extractor = require("smart-motion.extractors.pairs")
 
 ---@type SmartMotionRegistry<SmartMotionExtractorModuleEntry>
 local extractors = require("smart-motion.core.registry")("extractors")
@@ -96,6 +97,41 @@ extractors.register_many({
 	pass_through = {
 		run = utils.module_wrapper(pass_through.run),
 		metadata = pass_through.metadata,
+	},
+	-- Single pairs extractor: reads pair_scope and is_surround from motion_state.
+	-- Used by textobject registrations where inside/around/surround overrides
+	-- set these values before the extractor runs.
+	pairs = {
+		run = utils.module_wrapper(pairs_extractor.run),
+		metadata = pairs_extractor.metadata,
+	},
+	-- Legacy aliases for backwards compatibility with existing motion configs
+	pairs_inside = {
+		run = utils.module_wrapper(pairs_extractor.run),
+		metadata = vim.tbl_deep_extend("force", pairs_extractor.metadata, {
+			motion_state = {
+				pair_scope = "inside",
+				is_surround = false,
+			},
+		}),
+	},
+	pairs_around = {
+		run = utils.module_wrapper(pairs_extractor.run),
+		metadata = vim.tbl_deep_extend("force", pairs_extractor.metadata, {
+			motion_state = {
+				pair_scope = "around",
+				is_surround = false,
+			},
+		}),
+	},
+	pairs_surround = {
+		run = utils.module_wrapper(pairs_extractor.run),
+		metadata = vim.tbl_deep_extend("force", pairs_extractor.metadata, {
+			motion_state = {
+				pair_scope = "inside",
+				is_surround = true,
+			},
+		}),
 	},
 })
 

--- a/lua/smart-motion/extractors/pairs.lua
+++ b/lua/smart-motion/extractors/pairs.lua
@@ -1,0 +1,66 @@
+local log = require("smart-motion.core.log")
+
+---@type SmartMotionExtractorModuleEntry
+local M = {}
+
+--- Transforms pair data into SmartMotionTargets based on pair_scope and is_surround.
+--- @param ctx SmartMotionContext
+--- @param cfg SmartMotionConfig
+--- @param motion_state SmartMotionMotionState
+--- @param data table Pair data from the pairs collector
+--- @return table|nil Target object
+function M.run(ctx, cfg, motion_state, data)
+	local pair_scope = motion_state.pair_scope or "inside"
+	local is_surround = motion_state.is_surround or false
+
+	if is_surround then
+		-- Surround mode: target spans full pair, delimiter positions preserved in metadata
+		return {
+			text = data.full_text,
+			start_pos = { row = data.open_pos.start.row, col = data.open_pos.start.col },
+			end_pos = { row = data.close_pos["end"].row, col = data.close_pos["end"].col },
+			type = "pairs",
+			metadata = {
+				open_pos = data.open_pos,
+				close_pos = data.close_pos,
+				pair_open = data.pair_open,
+				pair_close = data.pair_close,
+				is_surround = true,
+				-- Pass through extra fields from collectors (func_name, tag_name, etc.)
+				func_name = data.func_name,
+				tag_name = data.tag_name,
+			},
+		}
+	elseif pair_scope == "around" then
+		-- Around mode: target spans open start to close end
+		return {
+			text = data.full_text,
+			start_pos = { row = data.open_pos.start.row, col = data.open_pos.start.col },
+			end_pos = { row = data.close_pos["end"].row, col = data.close_pos["end"].col },
+			type = "pairs",
+			metadata = {
+				pair_open = data.pair_open,
+				pair_close = data.pair_close,
+			},
+		}
+	else
+		-- Inside mode: target spans content between delimiters
+		return {
+			text = data.content_text,
+			start_pos = { row = data.open_pos["end"].row, col = data.open_pos["end"].col },
+			end_pos = { row = data.close_pos.start.row, col = data.close_pos.start.col },
+			type = "pairs",
+			metadata = {
+				pair_open = data.pair_open,
+				pair_close = data.pair_close,
+			},
+		}
+	end
+end
+
+M.metadata = {
+	label = "Pairs Extractor",
+	description = "Transforms pair data into targets based on scope (inside/around/surround)",
+}
+
+return M

--- a/lua/smart-motion/highlight_setup.lua
+++ b/lua/smart-motion/highlight_setup.lua
@@ -11,7 +11,7 @@ local default_highlights = {
 	SmartMotionDim = { fg = "#555555", bg = "none" },
 	SmartMotionSearchPrefix = { fg = "#BBBBBB", bg = "none" },
 	SmartMotionSearchPrefixDim = { fg = "#888888", bg = "none" },
-	SmartMotionSelected = { fg = "#FAFAFA", bg = "#2FD070", bold = true },
+	SmartMotionSelected = { fg = "#FAFAFA", bg = "#2FD0FF", bold = true },
 }
 
 local background_highlights = {
@@ -22,7 +22,7 @@ local background_highlights = {
 	SmartMotionDim = { fg = "#555555", bg = "none" },
 	SmartMotionSearchPrefix = { fg = "#E0E0E0", bg = "#333333" },
 	SmartMotionSearchPrefixDim = { fg = "#AAAAAA", bg = "#1F1F1F" },
-	SmartMotionSelected = { fg = "#FAFAFA", bg = "#2FD070", bold = true },
+	SmartMotionSelected = { fg = "#FAFAFA", bg = "#2FD0FF", bold = true },
 }
 
 local M = {}

--- a/lua/smart-motion/init.lua
+++ b/lua/smart-motion/init.lua
@@ -80,6 +80,13 @@ function M.setup(user_config)
 		get_by_name = registries.motions.get_by_name,
 	}
 
+	M.textobjects = {
+		register = registries.motions.register_textobject,
+		register_many = registries.motions.register_many_textobjects,
+		get = registries.motions.get_textobject,
+		has = registries.motions.has_textobject,
+	}
+
 	M.collectors = {
 		register = registries.collectors.register,
 		register_many = registries.collectors.register_many,

--- a/lua/smart-motion/motions/init.lua
+++ b/lua/smart-motion/motions/init.lua
@@ -223,4 +223,69 @@ function motions.get_composable_by_key(key)
 	return nil
 end
 
+-- =============================================================================
+-- Textobject Registry
+-- =============================================================================
+-- Textobjects are targets that work with i/a prefixes (e.g., "f" for function,
+-- "(" for parens). They live in a separate registry from composable motions so
+-- the same key can mean different things in different contexts:
+--   f composable = 2-char find
+--   f textobject = function (treesitter)
+--
+-- Each textobject declares pipeline components (collector, extractor, etc.) and
+-- motion_state overrides for each prefix via `inside`, `around`, and optionally
+-- `surround` fields. These are plain motion_state fragments.
+-- =============================================================================
+
+--- @type table<string, SmartMotionTextobjectEntry>
+motions.textobjects = {}
+
+--- Register a textobject by key.
+--- @param key string Single character key (e.g., "(", "f", "a")
+--- @param entry SmartMotionTextobjectEntry
+function motions.register_textobject(key, entry)
+	if not utils.is_non_empty_string(key) then
+		log.error("[Textobject Registry] Textobject must have a non-empty key.")
+		return
+	end
+
+	entry.key = key
+	entry.metadata = entry.metadata or {}
+	entry.metadata.label = entry.metadata.label or key
+	entry.metadata.motion_state = entry.metadata.motion_state or {}
+	entry.inside = entry.inside or {}
+	entry.around = entry.around or {}
+	entry.default = entry.default or "around"
+
+	motions.textobjects[key] = entry
+end
+
+--- Register multiple textobjects.
+--- @param tbl table<string, SmartMotionTextobjectEntry>
+--- @param opts? { override?: boolean }
+function motions.register_many_textobjects(tbl, opts)
+	opts = opts or {}
+	for key, entry in pairs(tbl) do
+		if not opts.override and motions.textobjects[key] then
+			log.warn("[Textobject Registry] Skipping already-registered textobject: " .. key)
+		else
+			motions.register_textobject(key, entry)
+		end
+	end
+end
+
+--- Get a textobject by key.
+--- @param key string
+--- @return SmartMotionTextobjectEntry|nil
+function motions.get_textobject(key)
+	return motions.textobjects[key]
+end
+
+--- Check if a textobject is registered for the given key.
+--- @param key string
+--- @return boolean
+function motions.has_textobject(key)
+	return motions.textobjects[key] ~= nil
+end
+
 return motions

--- a/lua/smart-motion/presets.lua
+++ b/lua/smart-motion/presets.lua
@@ -1,4 +1,6 @@
-local HINT_POSITION = require("smart-motion.consts").HINT_POSITION
+local consts = require("smart-motion.consts")
+local HINT_POSITION = consts.HINT_POSITION
+local KEYWORD_PATTERN = consts.KEYWORD_PATTERN
 
 ---@type SmartMotionPresetsModule
 local presets = {}
@@ -609,6 +611,227 @@ function presets.misc(exclude)
 	end
 end
 
+--- @param exclude? table
+function presets.surround(exclude)
+	-- Apply surround_pad config to pair_defs
+	local cfg = require("smart-motion.config").validated
+	if cfg then
+		local pair_defs = require("smart-motion.utils.pair_defs")
+		pair_defs.pad_convention = cfg.surround_pad
+	end
+
+	local pair_types = {
+		{ "(", ")" },
+		{ "[", "]" },
+		{ "{", "}" },
+		{ "<", ">" },
+		{ '"', '"' },
+		{ "'", "'" },
+		{ "`", "`" },
+	}
+
+	-- Register pair text objects: accessed via i/a prefix in infer and x/o keymaps.
+	-- For asymmetric pairs, both open and close chars are registered (e.g. "(" and ")").
+	local textobjects = {}
+
+	for _, pair in ipairs(pair_types) do
+		local open = pair[1]
+		local close = pair[2]
+
+		local entry = {
+			collector = "pairs",
+			extractor = "pairs",
+			modifier = "weight_distance",
+			filter = "filter_visible",
+			visualizer = "hint_start",
+			metadata = {
+				label = open .. close .. " pair",
+				description = "Delimiter pair " .. open .. close,
+				motion_state = {
+					pair_chars = { { open, close } },
+					is_textobject = true,
+				},
+			},
+			inside = { pair_scope = "inside" },
+			around = { pair_scope = "around" },
+			surround = { pair_scope = "surround", is_surround = true },
+			default = "around",
+		}
+
+		textobjects[open] = entry
+		if open ~= close then
+			textobjects[close] = vim.deepcopy(entry)
+		end
+	end
+
+	-- HTML/XML tag textobject
+	textobjects["t"] = {
+		collector = "tags",
+		extractor = "pairs",
+		modifier = "weight_distance",
+		filter = "filter_visible",
+		visualizer = "hint_start",
+		metadata = {
+			label = "Tag",
+			description = "HTML/XML tag text object",
+			motion_state = {
+				is_textobject = true,
+			},
+		},
+		inside = { pair_scope = "inside" },
+		around = { pair_scope = "around" },
+		surround = { pair_scope = "surround", is_surround = true },
+		default = "around",
+	}
+
+	-- Quote alias: matches any quote type (", ', `)
+	textobjects["q"] = {
+		collector = "pairs",
+		extractor = "pairs",
+		modifier = "weight_distance",
+		filter = "filter_visible",
+		visualizer = "hint_start",
+		metadata = {
+			label = "Any quote",
+			description = "Nearest quote pair (double, single, or backtick)",
+			motion_state = {
+				pair_chars = { { '"', '"' }, { "'", "'" }, { "`", "`" } },
+				is_textobject = true,
+			},
+		},
+		inside = { pair_scope = "inside" },
+		around = { pair_scope = "around" },
+		surround = { pair_scope = "surround", is_surround = true },
+		default = "around",
+	}
+
+	presets._register_textobjects(textobjects, exclude)
+
+	-- Build excluded table from exclude param
+	local excluded = {}
+	if type(exclude) == "table" then
+		for k, v in pairs(exclude) do
+			if v == false then
+				excluded[k] = true
+			end
+		end
+	end
+
+	-- Surround operators: ds, cs, ys
+	-- ds/cs pre-set textobject_key = "surround" so infer looks up the next char
+	-- directly in the textobject registry and uses the surround overrides.
+	presets._register({
+		ds = {
+			infer = true,
+			action_key = "d",
+			collector = "pairs",
+			modifier = "weight_distance",
+			filter = "filter_visible",
+			visualizer = "hint_start",
+			action = "surround",
+			map = true,
+			modes = { "n" },
+			metadata = {
+				label = "Delete Surround",
+				description = "Delete surrounding delimiter pair",
+				motion_state = {
+					textobject_key = "surround",
+					allow_quick_action = false,
+				},
+			},
+		},
+		cs = {
+			infer = true,
+			action_key = "c",
+			collector = "pairs",
+			modifier = "weight_distance",
+			filter = "filter_visible",
+			visualizer = "hint_start",
+			action = "surround",
+			map = true,
+			modes = { "n" },
+			metadata = {
+				label = "Change Surround",
+				description = "Change surrounding delimiter pair",
+				motion_state = {
+					textobject_key = "surround",
+					allow_quick_action = false,
+				},
+			},
+		},
+		ys = {
+			infer = true,
+			collector = "lines",
+			modifier = "weight_distance",
+			filter = "filter_visible",
+			visualizer = "hint_start",
+			action = "surround_add",
+			map = true,
+			modes = { "n" },
+			metadata = {
+				label = "Surround Add",
+				description = "Add surround: ys{i/a}{motion}{delimiter}",
+				motion_state = {
+					allow_quick_action = false,
+					ia_resolve_composable = true,
+					word_pattern = KEYWORD_PATTERN,
+					expansion_enabled = true,
+				},
+			},
+		},
+	}, exclude)
+
+	-- Register gza (standalone surround add with word hints)
+	presets._register({
+		gza = {
+			collector = "lines",
+			extractor = "words",
+			modifier = "weight_distance",
+			filter = "filter_visible",
+			visualizer = "hint_start",
+			action = "surround_add",
+			map = true,
+			modes = { "n" },
+			metadata = {
+				label = "Surround Add (words)",
+				description = "Show word hints, pick target, then type delimiter to wrap",
+				motion_state = {
+					word_pattern = KEYWORD_PATTERN,
+					expansion_enabled = true,
+				},
+			},
+		},
+	}, exclude)
+
+	-- Register gzp (paste surround with word hints)
+	presets._register({
+		gzp = {
+			collector = "lines",
+			extractor = "words",
+			modifier = "weight_distance",
+			filter = "filter_visible",
+			visualizer = "hint_start",
+			action = "surround_paste",
+			map = true,
+			modes = { "n" },
+			metadata = {
+				label = "Surround Paste",
+				description = "Wrap a word target with the previously yanked delimiter pair",
+				motion_state = {
+					word_pattern = KEYWORD_PATTERN,
+				},
+			},
+		},
+	}, exclude)
+
+	-- Register S keymap for visual surround (no conflict: existing S is n/o only)
+	if not excluded["S"] then
+		vim.keymap.set("x", "S", function()
+			require("smart-motion.actions.surround_visual").run()
+		end, { desc = "Surround visual selection", noremap = true, silent = true })
+	end
+end
+
 --- @param exclude? string[]
 function presets.treesitter(exclude)
 	-- Broad list of function-like node types across languages.
@@ -802,121 +1025,75 @@ function presets.treesitter(exclude)
 		"formal_parameters",
 	}
 
-	-- Text objects: registered in x/o modes, compose with any operator via infer fallthrough
+	-- Text objects: registered in the textobject registry, accessed via i/a prefix.
+	-- The i/a keymaps in x/o modes dispatch to the textobject pipeline automatically.
+	-- Operators (d/y/c) access textobjects via i/a prefix handling in infer.
+	presets._register_textobjects({
+		f = {
+			collector = "treesitter",
+			extractor = "pass_through",
+			modifier = "weight_distance",
+			filter = "filter_visible",
+			visualizer = "hint_start",
+			metadata = {
+				label = "Function",
+				description = "Function text object",
+				motion_state = {
+					ts_node_types = function_node_types,
+					is_textobject = true,
+				},
+			},
+			inside = { ts_inner_body = true },
+			around = {},
+			surround = {
+				_collector_override = "function_calls",
+				_extractor_override = "pairs",
+				pair_scope = "surround",
+				is_surround = true,
+			},
+			default = "around",
+		},
+		c = {
+			collector = "treesitter",
+			extractor = "pass_through",
+			modifier = "weight_distance",
+			filter = "filter_visible",
+			visualizer = "hint_start",
+			metadata = {
+				label = "Class",
+				description = "Class/struct text object",
+				motion_state = {
+					ts_node_types = class_node_types,
+					is_textobject = true,
+				},
+			},
+			inside = { ts_inner_body = true },
+			around = {},
+			default = "around",
+		},
+		a = {
+			collector = "treesitter",
+			extractor = "pass_through",
+			modifier = "weight_distance",
+			filter = "filter_visible",
+			visualizer = "hint_start",
+			metadata = {
+				label = "Argument",
+				description = "Argument/parameter text object",
+				motion_state = {
+					ts_node_types = arg_container_types,
+					ts_yield_children = true,
+					is_textobject = true,
+				},
+			},
+			inside = {},
+			around = { ts_around_separator = true },
+			default = "inside",
+		},
+	}, exclude)
+
+	-- fn stays as a composable motion (not a textobject — no i/a prefix)
 	presets._register({
-		af = {
-			collector = "treesitter",
-			extractor = "pass_through",
-			modifier = "weight_distance",
-			filter = "filter_visible",
-			visualizer = "hint_start",
-			action = "textobject_select",
-			map = true,
-			modes = { "x", "o" },
-			metadata = {
-				label = "Around Function",
-				description = "Select around a function",
-				motion_state = {
-					ts_node_types = function_node_types,
-					is_textobject = true,
-				},
-			},
-		},
-		["if"] = {
-			collector = "treesitter",
-			extractor = "pass_through",
-			modifier = "weight_distance",
-			filter = "filter_visible",
-			visualizer = "hint_start",
-			action = "textobject_select",
-			map = true,
-			modes = { "x", "o" },
-			metadata = {
-				label = "Inside Function",
-				description = "Select inside a function body",
-				motion_state = {
-					ts_node_types = function_node_types,
-					ts_inner_body = true,
-					is_textobject = true,
-				},
-			},
-		},
-		ac = {
-			collector = "treesitter",
-			extractor = "pass_through",
-			modifier = "weight_distance",
-			filter = "filter_visible",
-			visualizer = "hint_start",
-			action = "textobject_select",
-			map = true,
-			modes = { "x", "o" },
-			metadata = {
-				label = "Around Class",
-				description = "Select around a class/struct",
-				motion_state = {
-					ts_node_types = class_node_types,
-					is_textobject = true,
-				},
-			},
-		},
-		ic = {
-			collector = "treesitter",
-			extractor = "pass_through",
-			modifier = "weight_distance",
-			filter = "filter_visible",
-			visualizer = "hint_start",
-			action = "textobject_select",
-			map = true,
-			modes = { "x", "o" },
-			metadata = {
-				label = "Inside Class",
-				description = "Select inside a class/struct body",
-				motion_state = {
-					ts_node_types = class_node_types,
-					ts_inner_body = true,
-					is_textobject = true,
-				},
-			},
-		},
-		aa = {
-			collector = "treesitter",
-			extractor = "pass_through",
-			modifier = "weight_distance",
-			filter = "filter_visible",
-			visualizer = "hint_start",
-			action = "textobject_select",
-			map = true,
-			modes = { "x", "o" },
-			metadata = {
-				label = "Around Argument",
-				description = "Select around an argument (including separator)",
-				motion_state = {
-					ts_node_types = arg_container_types,
-					ts_yield_children = true,
-					ts_around_separator = true,
-					is_textobject = true,
-				},
-			},
-		},
-		ia = {
-			collector = "treesitter",
-			extractor = "pass_through",
-			modifier = "weight_distance",
-			filter = "filter_visible",
-			visualizer = "hint_start",
-			action = "textobject_select",
-			map = true,
-			modes = { "x", "o" },
-			metadata = {
-				label = "Inside Argument",
-				description = "Select inside an argument (without separator)",
-				motion_state = {
-					ts_node_types = arg_container_types,
-					ts_yield_children = true,
-					is_textobject = true,
-				},
-			},
-		},
 		fn = {
 			composable = true,
 			collector = "treesitter",
@@ -1246,6 +1423,42 @@ function presets._register(motions_list, user_overrides)
 	end
 
 	registries.motions.register_many_motions(final_motions)
+end
+
+--- Internal textobject registration logic with optional filtering.
+--- Same override/exclude pattern as _register for consistency.
+--- @param textobjects_list table<string, SmartMotionTextobjectEntry>
+--- @param user_overrides? table
+function presets._register_textobjects(textobjects_list, user_overrides)
+	local registries = require("smart-motion.core.registries"):get()
+	user_overrides = user_overrides or {}
+
+	if user_overrides == false then
+		return
+	end
+
+	local final = {}
+
+	for key, entry in pairs(textobjects_list) do
+		local override = user_overrides[key]
+
+		if override == false then
+			goto continue
+		end
+
+		if type(override) == "table" then
+			final[key] = vim.tbl_deep_extend("force", entry, override)
+		else
+			final[key] = entry
+		end
+
+		::continue::
+	end
+
+	registries.motions.register_many_textobjects(final)
+
+	-- Register i/a keymaps in x/o modes (idempotent, only registers once)
+	require("smart-motion.core.textobject_keymaps").setup()
 end
 
 return presets

--- a/lua/smart-motion/utils/module_loader.lua
+++ b/lua/smart-motion/utils/module_loader.lua
@@ -25,10 +25,18 @@ function M.get_modules(ctx, cfg, motion_state, keys)
 			module = registry.get_by_name(name)
 
 			--
-			-- Special handle for actions
+			-- Special handle for actions:
+			-- If a composable motion explicitly sets an action (e.g. surround),
+			-- use that action by name. Otherwise fall back to key-based lookup
+			-- for infer motions (d→delete_jump, y→yank_jump, etc.).
 			--
 			if key == "action" and motion.infer and action_key then
-				module = registry.get_by_key(action_key)
+				if motion.action and motion.action ~= "default" then
+					module = registry.get_by_name(motion.action)
+				end
+				if not module or not module.run then
+					module = registry.get_by_key(action_key)
+				end
 			end
 
 			if (not module or not module.run) and registry.get_by_name("default") then

--- a/lua/smart-motion/utils/pair_defs.lua
+++ b/lua/smart-motion/utils/pair_defs.lua
@@ -1,0 +1,93 @@
+local M = {}
+
+--- Padding convention for surround operations.
+--- Set via config: surround_pad = "opening" | "closing" | false
+--- "opening" (default): opening chars (e.g. `(`) add padding → `( word )`
+--- "closing": closing chars (e.g. `)`) add padding → `( word )`
+--- false: no padding ever
+M.pad_convention = "opening"
+
+--- Delimiter pair definitions.
+--- @type table<string, string>
+M.PAIRS = {
+	["("] = ")",
+	["{"] = "}",
+	["["] = "]",
+	["<"] = ">",
+	['"'] = '"',
+	["'"] = "'",
+	["`"] = "`",
+}
+
+--- Closing char → opening char aliases for asymmetric pairs.
+--- @type table<string, string>
+M.ALIASES = {
+	[")"] = "(",
+	["}"] = "{",
+	["]"] = "[",
+	[">"] = "<",
+}
+
+--- Special pair types that require a name prompt.
+--- @type table<string, { type: string, prompt: string }>
+M.SPECIAL_PAIRS = {
+	t = { type = "tag", prompt = "Tag: " },
+	f = { type = "function_call", prompt = "Function: " },
+}
+
+--- Builds open/close text for a special pair given a user-supplied name.
+--- @param special_type string "tag" or "function_call"
+--- @param name string The tag name or function name
+--- @return { open: string, close: string, pad: boolean }|nil
+function M.build_special_pair(special_type, name)
+	if not name or name == "" then
+		return nil
+	end
+	if special_type == "tag" then
+		return { open = "<" .. name .. ">", close = "</" .. name .. ">", pad = false }
+	elseif special_type == "function_call" then
+		return { open = name .. "(", close = ")", pad = false }
+	end
+	return nil
+end
+
+--- Returns the open/close pair for any delimiter character.
+--- Padding is determined by pad_convention and whether the char is asymmetric.
+--- Symmetric pairs (quotes) never pad.
+--- For special chars (t, f), returns a special result with a prompt field.
+--- @param char string A single open or close delimiter character
+--- @return { open: string, close: string, pad: boolean, special?: string, prompt?: string }|nil
+function M.get_pair(char)
+	-- Special pair types that need a name prompt
+	if M.SPECIAL_PAIRS[char] then
+		local special = M.SPECIAL_PAIRS[char]
+		return { special = special.type, prompt = special.prompt }
+	end
+
+	local is_opening = M.PAIRS[char] ~= nil
+	local is_closing = M.ALIASES[char] ~= nil
+
+	local open, close
+	if is_opening then
+		open = char
+		close = M.PAIRS[char]
+	elseif is_closing then
+		open = M.ALIASES[char]
+		close = M.PAIRS[open]
+	else
+		return nil
+	end
+
+	-- Symmetric pairs (quotes) never pad
+	local is_asymmetric = open ~= close
+	local pad = false
+	if is_asymmetric and M.pad_convention == "opening" then
+		pad = is_opening
+	elseif is_asymmetric and M.pad_convention == "closing" then
+		pad = is_closing
+	end
+
+	return { open = open, close = close, pad = pad }
+end
+
+return M

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,7 +6,7 @@ SmartMotion has two kinds of tests: an **automated test suite** run headlessly v
 
 ## Automated Test Suite
 
-470 tests across 41 files covering pipeline engine, registries, filters, config validation, history persistence, and more.
+548 tests across 43 files covering pipeline engine, registries, filters, config validation, history persistence, textobjects, pairs, surround, and more.
 
 ### Running Tests
 
@@ -109,6 +109,8 @@ The default test config (`helpers.test_config`) sets `flow_state_timeout_ms = 0`
 | `test_text_search.lua` | Literal match extraction, `\V` pattern, registry variants |
 | `test_utils.lua` | Utility functions |
 | `test_visual_select.lua` | `_collect_word_targets`, textobject visual selection |
+| `test_textobjects.lua` | 44 tests for the textobject registry, key resolver, treesitter/pair textobjects, surround operators, backwards compatibility, infer integration |
+| `test_pairs.lua` | 34 tests for pair definitions, pair collector, pair extractor, surround presets |
 
 ### Writing New Tests
 

--- a/tests/manual_surround_test.lua
+++ b/tests/manual_surround_test.lua
@@ -1,0 +1,258 @@
+-- Manual testing file for textobjects, surround, & target expansion
+-- Open this file in Neovim with smart-motion loaded:
+--   require("smart-motion").setup({ presets = { treesitter = true, surround = true } })
+--
+-- NOTE: This file intentionally contains invalid Lua (angle brackets, backticks)
+-- to verify that the pattern-based fallback works when treesitter can't parse.
+
+-- =============================================================================
+-- 1. PAIR TEXT OBJECTS (i/a + delimiter)
+--    Works in operator-pending (d/y/c) and visual (v) modes
+-- =============================================================================
+
+-- Test: di( → delete inside parens | da( → delete around parens
+-- Test: di) → same as di( (closing char alias)
+local basic = foo(bar) + baz(qux)
+local nested = foo(bar(baz))
+local empty = foo() + bar()
+
+-- Test: di[ → delete inside brackets | da[ → delete around brackets
+-- Test: di{ → delete inside braces | da{ → delete around braces
+-- Test: di< → delete inside angles | da< → delete around angles
+local tbl = { key = "value", other = "data" }
+local arr = list[1] + list[2]
+local ang = Vec<i32>
+
+-- Test: di" → delete inside quotes | da" → delete around quotes
+-- Test: di' → delete inside single quotes
+-- Test: di` → delete inside backticks
+local str = "hello world"
+local char = 'single quotes'
+local tmpl = `backtick string`
+
+-- Test: vi( → visually select inside parens
+-- Test: va{ → visually select around braces
+local multi = fn(
+  arg1,
+  arg2,
+  arg3
+)
+
+-- =============================================================================
+-- 2. TREESITTER TEXT OBJECTS (i/a + f/c/a)
+--    Requires treesitter parser for the buffer's language
+-- =============================================================================
+
+-- Test: daf → delete around function (entire function including signature)
+-- Test: dif → delete inside function (body only)
+-- Test: vaf → visually select around function
+-- Test: yif → yank inside function
+-- Test: cif → change inside function
+local function sample_function(x, y)
+  local result = x + y
+  return result
+end
+
+-- Test: dac → delete around class (n/a in Lua, test in TS/Python/etc)
+-- Test: dic → delete inside class
+
+-- Test: dia → delete inside argument (just the argument text)
+-- Test: daa → delete around argument (includes trailing comma/separator)
+-- Test: via → visually select inside argument
+local function with_args(first, second, third)
+  return first + second + third
+end
+
+-- =============================================================================
+-- 3. SURROUND DELETE: ds + delimiter
+--    Pre-sets textobject_key="surround", reads next char as pair type
+-- =============================================================================
+
+-- Test: ds( → delete surrounding parens (leaves content)
+-- Test: ds) → same as ds(
+local del1 = (delete_these_parens)
+local del2 = {delete_these_braces}
+local del3 = [delete_these_brackets]
+local del4 = "delete_these_quotes"
+local del5 = 'delete_single_quotes'
+local del6 = <delete_angles>
+
+-- =============================================================================
+-- 4. SURROUND CHANGE: cs + delimiter
+--    Pre-sets textobject_key="surround", reads next char, prompts for replacement
+--    Selected delimiters highlight in blue while waiting for input
+-- =============================================================================
+
+-- Test: cs( → change surrounding parens (prompts for new delimiter)
+-- Test: cs" → change surrounding quotes
+-- Test: cs( then type [ → changes () to []
+-- Test: cs( then type { → changes () to { } (opening = padded)
+-- Test: cs( then type } → changes () to {} (closing = tight)
+local change1 = (change_to_brackets)
+local change2 = [change_to_parens]
+local change3 = "change_to_single_quotes"
+
+-- =============================================================================
+-- 5. SURROUND ADD: ys + i/a + motion + delimiter
+--    Reads i/a prefix from user input, then motion target, then delimiter
+--    Selected target highlights in blue while waiting for delimiter
+-- =============================================================================
+
+-- Test: ysaw( → ys + around + word + ( → wrap word with ( word )
+-- Test: ysaw) → ys + around + word + ) → wrap word with (word) (no padding)
+-- Test: ysiw" → ys + inside + word + " → wrap word with "word"
+-- Test: ysaf( → ys + around + function + ( → wrap function with parens
+local add1 = wrap_this_word in parens
+local add2 = another_target here too
+
+-- =============================================================================
+-- 6. TARGET EXPANSION (+ / -)
+--    After picking a target with ys or gza, expand before typing delimiter
+-- =============================================================================
+
+-- Test: ysaw → pick "one" → + → + → ( → wraps "( one two three )"
+-- Test: ysaw → pick "two" → - → + → ( → wraps "( one two three )"
+-- Test: ysaw → pick "one" → + → BS → ( → wraps "( one )" (BS undoes last +)
+-- Test: gza → pick "one" → + → + → " → wraps '"one two three"'
+-- Test: ysaw → pick "one" → ( → wraps "( one )" (no expansion, just type delimiter)
+local one = "target"
+local two = "target"
+local three = "target"
+local four = "target"
+local five = "target"
+
+-- Verify dim + appears on next word, dim - on previous word after selection
+-- Verify highlights update as you expand
+-- Verify ESC cancels the operation
+-- Verify BS shrinks the last expansion
+
+-- =============================================================================
+-- 7. STANDALONE OPERATIONS
+-- =============================================================================
+
+-- Test: gza → show word hints, pick target, type delimiter to wrap
+-- Test: gza → pick target → + → + → type delimiter (expansion works here too)
+local standalone1 = wrap_this_word
+local standalone2 = another_target here
+
+-- Test: gzp → paste surround (yank a pair first with ds, then gzp wraps with stored pair)
+local paste1 = paste_surround_here
+local paste2 = and_here_too
+
+-- Test: Visual S → select text in visual mode, press S, type delimiter
+local vis1 = select this text
+local vis2 = wrap multiple words
+
+-- =============================================================================
+-- 8. QUOTE ALIAS (q)
+--    Matches any quote type: ", ', `
+-- =============================================================================
+
+-- Test: dsq → labels on ALL quote pairs (double, single, backtick) → pick one → removed
+-- Test: csq → labels on all quotes → pick one → type replacement char
+-- Test: diq → delete inside nearest quote (any type)
+-- Test: daq → delete around nearest quote (any type)
+-- Test: viq → visually select inside nearest quote
+-- Test: vaq → visually select around nearest quote
+local q1 = "double quoted string"
+local q2 = 'single quoted string'
+local q3 = `backtick quoted string`
+local q_mixed = "double" .. 'single' .. `backtick`
+
+-- =============================================================================
+-- 9. HTML/XML TAGS (t)
+--    Uses treesitter for HTML/JSX/TSX, pattern fallback for others
+-- =============================================================================
+
+-- Test: dst → labels on all tag pairs → pick one → tags removed, content kept
+-- Test: cst → labels on tags → pick one → tag name deleted from BOTH opening/closing
+--       → cursor enters insert mode in opening tag after < → type new name
+--       → closing tag mirrors input in real-time (blue highlight) → ESC when done
+--       Example: cst on <div>foo</div> → <|>foo</> → type "span" → <span>foo</span>
+-- Test: dit → delete inside tag
+-- Test: dat → delete around tag (including tag delimiters)
+-- Test: vit → visually select inside tag
+-- Test: vat → visually select around tag
+-- Test: ysiw t → word labels → pick → prompts "Tag:" → type tag name → wraps
+-- Test: Visual S then type t → prompts "Tag:" → wraps selection with tag
+local tag1 = "<div>hello world</div>"
+local tag2 = "<span>inner text</span>"
+local tag3 = "<p>paragraph content</p>"
+local tag_nested = "<div><span>nested</span></div>"
+local tag_attrs = '<div class="foo">with attributes</div>'
+local tag_self = "<br/>"
+
+-- =============================================================================
+-- 10. FUNCTION CALLS (f surround)
+--     dsf/csf target function CALLS, not definitions
+--     dif/daf still work as treesitter function body text objects
+-- =============================================================================
+
+-- Test: dsf → labels on function calls → pick one → unwrapped
+--       print(foo, bar) → foo, bar
+-- Test: csf → labels on calls → pick one → function name deleted
+--       → cursor enters insert mode at name position → type new name → ESC
+--       Example: csf on console.log(x) → |(x) in insert mode → type "warn" → warn(x)
+-- Test: dif → still deletes inside function BODY (treesitter, unchanged)
+-- Test: daf → still deletes around function BODY (treesitter, unchanged)
+local fc1 = print(foo, bar)
+local fc2 = string.format("%s %s", a, b)
+local fc3 = math.max(1, 2, 3)
+local fc_nested = outer(inner(x))
+local fc_method = obj:method(arg)
+local fc_chain = foo(bar(baz(1)))
+
+-- =============================================================================
+-- 11. COMPOSABLE MOTIONS STILL WORK (no regression)
+--     These should NOT be affected by the textobject system
+-- =============================================================================
+
+-- Test: f → 2-char find (composable, not a textobject in this context)
+-- Test: s → live search
+-- Test: w → word jump after cursor
+-- Test: b → word jump before cursor
+-- Test: e → word end jump
+-- Test: dd → delete line (infer: d + d = quick action)
+-- Test: yy → yank line
+-- Test: dw → delete to word start
+-- Test: cw → change to word start
+
+-- =============================================================================
+-- 12. TREESITTER NAVIGATION MOTIONS (composable, not textobjects)
+-- =============================================================================
+
+-- Test: ]] → jump to next function
+-- Test: [[ → jump to previous function
+-- Test: ]c → jump to next class
+-- Test: [c → jump to previous class
+-- Test: ]b → jump to next block/scope
+-- Test: [b → jump to previous block/scope
+-- Test: fn → select function name (composable, operator-pending only)
+
+local function nav_target_one()
+  return 1
+end
+
+local function nav_target_two()
+  if true then
+    for i = 1, 10 do
+      print(i)
+    end
+  end
+  return 2
+end
+
+local function nav_target_three(a, b, c)
+  return a + b + c
+end
+
+-- =============================================================================
+-- 13. NATIVE VIM FALLBACK
+--     Unregistered textobject keys should fall back to native Vim
+-- =============================================================================
+
+-- Test: diw → native Vim delete inside word (w not in textobject registry)
+-- Test: daw → native Vim delete around word
+-- Test: dip → native Vim delete inside paragraph
+-- Test: dis → native Vim delete inside sentence
+local fallback_word = test_native_fallback

--- a/tests/test_expansion.lua
+++ b/tests/test_expansion.lua
@@ -1,0 +1,182 @@
+local helpers = require("tests.helpers")
+local MiniTest = require("mini_test")
+local T = MiniTest.new_set()
+
+-- Setup
+T["expansion"] = MiniTest.new_set({
+	hooks = {
+		pre_case = function()
+			helpers.setup_plugin({
+				presets = { words = true, delete = true, yank = true, change = true },
+			})
+		end,
+	},
+})
+
+-- =============================================================================
+-- Module loading
+-- =============================================================================
+
+T["expansion"]["module loads"] = function()
+	local expansion = require("smart-motion.core.expansion")
+	MiniTest.expect.equality(type(expansion.run), "function")
+end
+
+-- =============================================================================
+-- Config
+-- =============================================================================
+
+T["expansion"]["config has expansion_keys defaults"] = function()
+	local config = require("smart-motion.config")
+	local cfg = config.validated
+	MiniTest.expect.equality(type(cfg.expansion_keys), "table")
+	MiniTest.expect.equality(cfg.expansion_keys["+"], "expand_forward")
+	MiniTest.expect.equality(cfg.expansion_keys["-"], "expand_backward")
+	MiniTest.expect.equality(cfg.expansion_keys["<BS>"], "shrink")
+end
+
+T["expansion"]["config validates expansion_keys"] = function()
+	helpers.setup_plugin({
+		expansion_keys = {
+			["<M-n>"] = "expand_forward",
+			["<M-p>"] = "expand_backward",
+		},
+	})
+	local config = require("smart-motion.config")
+	MiniTest.expect.equality(config.validated.expansion_keys["<M-n>"], "expand_forward")
+	MiniTest.expect.equality(config.validated.expansion_keys["<M-p>"], "expand_backward")
+end
+
+T["expansion"]["config expansion_keys = false disables"] = function()
+	helpers.setup_plugin({ expansion_keys = false })
+	local config = require("smart-motion.config")
+	MiniTest.expect.equality(config.validated.expansion_keys, false)
+end
+
+-- =============================================================================
+-- Expansion enabled on operators
+-- =============================================================================
+
+T["expansion"]["d/y/c do NOT have expansion_enabled"] = function()
+	local motions = require("smart-motion.motions")
+	MiniTest.expect.equality(motions.get_by_key("d").metadata.motion_state.expansion_enabled, nil)
+	MiniTest.expect.equality(motions.get_by_key("y").metadata.motion_state.expansion_enabled, nil)
+	MiniTest.expect.equality(motions.get_by_key("c").metadata.motion_state.expansion_enabled, nil)
+end
+
+T["expansion"]["surround presets have expansion_enabled"] = function()
+	helpers.setup_plugin({
+		presets = { words = true, surround = true },
+	})
+	local motions = require("smart-motion.motions")
+	local ys = motions.get_by_key("ys")
+	MiniTest.expect.equality(ys.metadata.motion_state.expansion_enabled, true)
+	local gza = motions.get_by_key("gza")
+	MiniTest.expect.equality(gza.metadata.motion_state.expansion_enabled, true)
+end
+
+-- =============================================================================
+-- Expansion logic (unit tests on internals)
+-- =============================================================================
+
+T["expansion"]["skips when expansion_enabled is false"] = function()
+	local expansion = require("smart-motion.core.expansion")
+	local motion_state = {
+		expansion_enabled = false,
+		selected_jump_target = { start_pos = { row = 0, col = 0 }, end_pos = { row = 0, col = 3 } },
+	}
+	-- Should return immediately without blocking
+	expansion.run({}, {}, motion_state)
+	-- Target should be unchanged
+	MiniTest.expect.equality(motion_state.selected_jump_target.start_pos.col, 0)
+end
+
+T["expansion"]["skips when no selected target"] = function()
+	local expansion = require("smart-motion.core.expansion")
+	local motion_state = {
+		expansion_enabled = true,
+		selected_jump_target = nil,
+	}
+	expansion.run({}, {}, motion_state)
+	MiniTest.expect.equality(motion_state.selected_jump_target, nil)
+end
+
+T["expansion"]["skips when fewer than 2 targets"] = function()
+	local expansion = require("smart-motion.core.expansion")
+	local target = { start_pos = { row = 0, col = 0 }, end_pos = { row = 0, col = 3 } }
+	local motion_state = {
+		expansion_enabled = true,
+		selected_jump_target = target,
+		jump_targets = { target },
+	}
+	expansion.run({}, {}, motion_state)
+	MiniTest.expect.equality(motion_state.selected_jump_target, target)
+end
+
+T["expansion"]["skips when no expansion_keys in config"] = function()
+	local expansion = require("smart-motion.core.expansion")
+	local target = {
+		start_pos = { row = 0, col = 0 },
+		end_pos = { row = 0, col = 3 },
+		metadata = {},
+	}
+	local motion_state = {
+		expansion_enabled = true,
+		selected_jump_target = target,
+		jump_targets = { target, { start_pos = { row = 0, col = 4 }, end_pos = { row = 0, col = 7 } } },
+	}
+	expansion.run({}, { expansion_keys = nil }, motion_state)
+	MiniTest.expect.equality(motion_state.selected_jump_target, target)
+end
+
+-- =============================================================================
+-- resolve_range with is_expanded_range
+-- =============================================================================
+
+T["expansion"]["resolve_range uses full range when is_expanded_range"] = function()
+	local utils = require("smart-motion.actions.utils")
+	local ctx = { cursor_line = 0, cursor_col = 0 }
+	local motion_state = {
+		is_expanded_range = true,
+		exclude_target = true, -- would normally change behavior
+		selected_jump_target = {
+			start_pos = { row = 2, col = 5 },
+			end_pos = { row = 2, col = 20 },
+		},
+	}
+	local sr, sc, er, ec = utils.resolve_range(ctx, motion_state)
+	MiniTest.expect.equality(sr, 2)
+	MiniTest.expect.equality(sc, 5)
+	MiniTest.expect.equality(er, 2)
+	MiniTest.expect.equality(ec, 20)
+end
+
+T["expansion"]["resolve_range normal behavior without is_expanded_range"] = function()
+	local utils = require("smart-motion.actions.utils")
+	local ctx = { cursor_line = 0, cursor_col = 0 }
+	local motion_state = {
+		selected_jump_target = {
+			start_pos = { row = 2, col = 5 },
+			end_pos = { row = 2, col = 20 },
+		},
+	}
+	local sr, sc, er, ec = utils.resolve_range(ctx, motion_state)
+	MiniTest.expect.equality(sr, 2)
+	MiniTest.expect.equality(sc, 5)
+	MiniTest.expect.equality(er, 2)
+	MiniTest.expect.equality(ec, 20)
+end
+
+-- =============================================================================
+-- Integration into exit flow
+-- =============================================================================
+
+T["expansion"]["exit.lua loads expansion module"] = function()
+	local exit = require("smart-motion.core.engine.exit")
+	MiniTest.expect.equality(type(exit.run), "function")
+	-- Verify expansion module is loadable
+	local expansion = require("smart-motion.core.expansion")
+	MiniTest.expect.equality(type(expansion.run), "function")
+end
+
+return T

--- a/tests/test_pairs.lua
+++ b/tests/test_pairs.lua
@@ -1,0 +1,678 @@
+local MiniTest = require("mini_test")
+local expect = MiniTest.expect
+local helpers = require("tests.helpers")
+
+local T = MiniTest.new_set({
+	hooks = {
+		pre_case = function()
+			helpers.setup_plugin()
+		end,
+		post_case = helpers.cleanup,
+	},
+})
+
+-- =============================================================================
+-- pair_defs
+-- =============================================================================
+
+T["pair_defs"] = MiniTest.new_set()
+
+T["pair_defs"]["get_pair returns correct pair for open char"] = function()
+	local pair_defs = require("smart-motion.utils.pair_defs")
+
+	local p = pair_defs.get_pair("(")
+	expect.equality(p.open, "(")
+	expect.equality(p.close, ")")
+
+	p = pair_defs.get_pair("{")
+	expect.equality(p.open, "{")
+	expect.equality(p.close, "}")
+
+	p = pair_defs.get_pair("[")
+	expect.equality(p.open, "[")
+	expect.equality(p.close, "]")
+
+	p = pair_defs.get_pair("<")
+	expect.equality(p.open, "<")
+	expect.equality(p.close, ">")
+end
+
+T["pair_defs"]["get_pair returns correct pair for close char"] = function()
+	local pair_defs = require("smart-motion.utils.pair_defs")
+
+	local p = pair_defs.get_pair(")")
+	expect.equality(p.open, "(")
+	expect.equality(p.close, ")")
+
+	p = pair_defs.get_pair("}")
+	expect.equality(p.open, "{")
+	expect.equality(p.close, "}")
+end
+
+T["pair_defs"]["get_pair handles symmetric delimiters"] = function()
+	local pair_defs = require("smart-motion.utils.pair_defs")
+
+	local p = pair_defs.get_pair('"')
+	expect.equality(p.open, '"')
+	expect.equality(p.close, '"')
+
+	p = pair_defs.get_pair("'")
+	expect.equality(p.open, "'")
+	expect.equality(p.close, "'")
+
+	p = pair_defs.get_pair("`")
+	expect.equality(p.open, "`")
+	expect.equality(p.close, "`")
+end
+
+T["pair_defs"]["get_pair returns nil for unknown char"] = function()
+	local pair_defs = require("smart-motion.utils.pair_defs")
+	expect.equality(pair_defs.get_pair("x"), nil)
+	expect.equality(pair_defs.get_pair("1"), nil)
+end
+
+-- =============================================================================
+-- pairs collector
+-- =============================================================================
+
+T["pairs collector"] = MiniTest.new_set()
+
+T["pairs collector"]["finds matching parentheses"] = function()
+	helpers.create_buf({ "foo(bar) baz(qux)" })
+	helpers.set_cursor(1, 0)
+
+	local collector = require("smart-motion.collectors.pairs")
+	local gen = collector.run()
+
+	local ctx = helpers.build_ctx()
+	local cfg = require("smart-motion.config").validated
+	local ms = { pair_chars = { { "(", ")" } } }
+
+	local results = {}
+	local ok, data = coroutine.resume(gen, ctx, cfg, ms)
+	while ok and data do
+		table.insert(results, data)
+		ok, data = coroutine.resume(gen, ctx, cfg, ms)
+	end
+
+	expect.equality(#results >= 2, true)
+	-- First pair: (bar)
+	expect.equality(results[1].pair_open, "(")
+	expect.equality(results[1].pair_close, ")")
+	expect.equality(results[1].content_text, "bar")
+end
+
+T["pairs collector"]["finds nested pairs"] = function()
+	helpers.create_buf({ "foo(bar(baz))" })
+	helpers.set_cursor(1, 0)
+
+	local collector = require("smart-motion.collectors.pairs")
+	local gen = collector.run()
+
+	local ctx = helpers.build_ctx()
+	local cfg = require("smart-motion.config").validated
+	local ms = { pair_chars = { { "(", ")" } } }
+
+	local results = {}
+	local ok, data = coroutine.resume(gen, ctx, cfg, ms)
+	while ok and data do
+		table.insert(results, data)
+		ok, data = coroutine.resume(gen, ctx, cfg, ms)
+	end
+
+	expect.equality(#results >= 2, true)
+end
+
+T["pairs collector"]["finds curly braces"] = function()
+	helpers.create_buf({ "if {x} then {y}" })
+	helpers.set_cursor(1, 0)
+
+	local collector = require("smart-motion.collectors.pairs")
+	local gen = collector.run()
+
+	local ctx = helpers.build_ctx()
+	local cfg = require("smart-motion.config").validated
+	local ms = { pair_chars = { { "{", "}" } } }
+
+	local results = {}
+	local ok, data = coroutine.resume(gen, ctx, cfg, ms)
+	while ok and data do
+		table.insert(results, data)
+		ok, data = coroutine.resume(gen, ctx, cfg, ms)
+	end
+
+	expect.equality(#results >= 2, true)
+	expect.equality(results[1].pair_open, "{")
+	expect.equality(results[1].pair_close, "}")
+end
+
+T["pairs collector"]["finds quotes on same line"] = function()
+	helpers.create_buf({ 'foo "bar" baz "qux"' })
+	helpers.set_cursor(1, 0)
+
+	local collector = require("smart-motion.collectors.pairs")
+	local gen = collector.run()
+
+	local ctx = helpers.build_ctx()
+	local cfg = require("smart-motion.config").validated
+	local ms = { pair_chars = { { '"', '"' } } }
+
+	local results = {}
+	local ok, data = coroutine.resume(gen, ctx, cfg, ms)
+	while ok and data do
+		table.insert(results, data)
+		ok, data = coroutine.resume(gen, ctx, cfg, ms)
+	end
+
+	expect.equality(#results >= 2, true)
+	expect.equality(results[1].content_text, "bar")
+end
+
+T["pairs collector"]["returns nothing when no pair_chars specified"] = function()
+	helpers.create_buf({ "foo(bar)" })
+	helpers.set_cursor(1, 0)
+
+	local collector = require("smart-motion.collectors.pairs")
+	local gen = collector.run()
+
+	local ctx = helpers.build_ctx()
+	local cfg = require("smart-motion.config").validated
+	local ms = {} -- no pair_chars
+
+	local results = {}
+	local ok, data = coroutine.resume(gen, ctx, cfg, ms)
+	while ok and data do
+		table.insert(results, data)
+		ok, data = coroutine.resume(gen, ctx, cfg, ms)
+	end
+
+	expect.equality(#results, 0)
+end
+
+-- =============================================================================
+-- pairs extractor
+-- =============================================================================
+
+T["pairs extractor"] = MiniTest.new_set()
+
+T["pairs extractor"]["inside scope extracts content between delimiters"] = function()
+	local extractor = require("smart-motion.extractors.pairs")
+
+	local data = {
+		open_pos = { start = { row = 0, col = 3 }, ["end"] = { row = 0, col = 4 } },
+		close_pos = { start = { row = 0, col = 7 }, ["end"] = { row = 0, col = 8 } },
+		pair_open = "(",
+		pair_close = ")",
+		content_text = "bar",
+		full_text = "(bar)",
+	}
+
+	local ms = { pair_scope = "inside", is_surround = false }
+	local result = extractor.run(nil, nil, ms, data)
+
+	expect.equality(result.text, "bar")
+	expect.equality(result.start_pos.row, 0)
+	expect.equality(result.start_pos.col, 4) -- after open delimiter
+	expect.equality(result.end_pos.col, 7)   -- before close delimiter
+	expect.equality(result.type, "pairs")
+end
+
+T["pairs extractor"]["around scope extracts full pair"] = function()
+	local extractor = require("smart-motion.extractors.pairs")
+
+	local data = {
+		open_pos = { start = { row = 0, col = 3 }, ["end"] = { row = 0, col = 4 } },
+		close_pos = { start = { row = 0, col = 7 }, ["end"] = { row = 0, col = 8 } },
+		pair_open = "(",
+		pair_close = ")",
+		content_text = "bar",
+		full_text = "(bar)",
+	}
+
+	local ms = { pair_scope = "around", is_surround = false }
+	local result = extractor.run(nil, nil, ms, data)
+
+	expect.equality(result.text, "(bar)")
+	expect.equality(result.start_pos.col, 3) -- open start
+	expect.equality(result.end_pos.col, 8)   -- close end
+end
+
+T["pairs extractor"]["surround mode preserves delimiter positions in metadata"] = function()
+	local extractor = require("smart-motion.extractors.pairs")
+
+	local data = {
+		open_pos = { start = { row = 0, col = 3 }, ["end"] = { row = 0, col = 4 } },
+		close_pos = { start = { row = 0, col = 7 }, ["end"] = { row = 0, col = 8 } },
+		pair_open = "(",
+		pair_close = ")",
+		content_text = "bar",
+		full_text = "(bar)",
+	}
+
+	local ms = { is_surround = true }
+	local result = extractor.run(nil, nil, ms, data)
+
+	expect.equality(result.text, "(bar)")
+	expect.equality(result.metadata.is_surround, true)
+	expect.equality(result.metadata.open_pos.start.col, 3)
+	expect.equality(result.metadata.close_pos.start.col, 7)
+	expect.equality(result.metadata.pair_open, "(")
+	expect.equality(result.metadata.pair_close, ")")
+end
+
+T["pairs extractor"]["defaults to inside scope"] = function()
+	local extractor = require("smart-motion.extractors.pairs")
+
+	local data = {
+		open_pos = { start = { row = 0, col = 3 }, ["end"] = { row = 0, col = 4 } },
+		close_pos = { start = { row = 0, col = 7 }, ["end"] = { row = 0, col = 8 } },
+		pair_open = "(",
+		pair_close = ")",
+		content_text = "bar",
+		full_text = "(bar)",
+	}
+
+	-- No pair_scope set — should default to "inside"
+	local ms = {}
+	local result = extractor.run(nil, nil, ms, data)
+
+	expect.equality(result.text, "bar")
+end
+
+-- =============================================================================
+-- surround action
+-- =============================================================================
+
+T["surround action"] = MiniTest.new_set()
+
+T["surround action"]["delete removes delimiters"] = function()
+	local bufnr = helpers.create_buf({ "foo(bar)baz" })
+	helpers.set_cursor(1, 0)
+
+	local surround = require("smart-motion.actions.surround")
+	local ctx = helpers.build_ctx()
+	local cfg = require("smart-motion.config").validated
+	local ms = {
+		motion = { action_key = "d" },
+		selected_jump_target = {
+			start_pos = { row = 0, col = 3 },
+			end_pos = { row = 0, col = 8 },
+			text = "(bar)",
+			metadata = {
+				bufnr = bufnr,
+				is_surround = true,
+				open_pos = { start = { row = 0, col = 3 }, ["end"] = { row = 0, col = 4 } },
+				close_pos = { start = { row = 0, col = 7 }, ["end"] = { row = 0, col = 8 } },
+				pair_open = "(",
+				pair_close = ")",
+			},
+		},
+	}
+
+	surround.run(ctx, cfg, ms)
+
+	local lines = helpers.get_buf_lines()
+	expect.equality(lines[1], "foobarbaz")
+end
+
+T["surround action"]["yank stores pair in register and global"] = function()
+	local bufnr = helpers.create_buf({ "foo(bar)baz" })
+	helpers.set_cursor(1, 0)
+
+	local surround = require("smart-motion.actions.surround")
+	local ctx = helpers.build_ctx()
+	local cfg = require("smart-motion.config").validated
+	local ms = {
+		motion = { action_key = "y" },
+		selected_jump_target = {
+			start_pos = { row = 0, col = 3 },
+			end_pos = { row = 0, col = 8 },
+			text = "(bar)",
+			metadata = {
+				bufnr = bufnr,
+				is_surround = true,
+				open_pos = { start = { row = 0, col = 3 }, ["end"] = { row = 0, col = 4 } },
+				close_pos = { start = { row = 0, col = 7 }, ["end"] = { row = 0, col = 8 } },
+				pair_open = "(",
+				pair_close = ")",
+			},
+		},
+	}
+
+	surround.run(ctx, cfg, ms)
+
+	-- Buffer should be unchanged
+	local lines = helpers.get_buf_lines()
+	expect.equality(lines[1], "foo(bar)baz")
+
+	-- Register should contain the pair characters
+	expect.equality(helpers.get_register('"'), "()")
+
+	-- Global should store pair for paste surround
+	expect.equality(vim.g.smart_motion_surround_pair, "()")
+end
+
+T["surround action"]["delete handles empty pair"] = function()
+	local bufnr = helpers.create_buf({ "foo()baz" })
+	helpers.set_cursor(1, 0)
+
+	local surround = require("smart-motion.actions.surround")
+	local ctx = helpers.build_ctx()
+	local cfg = require("smart-motion.config").validated
+	local ms = {
+		motion = { action_key = "d" },
+		selected_jump_target = {
+			start_pos = { row = 0, col = 3 },
+			end_pos = { row = 0, col = 5 },
+			text = "()",
+			metadata = {
+				bufnr = bufnr,
+				is_surround = true,
+				open_pos = { start = { row = 0, col = 3 }, ["end"] = { row = 0, col = 4 } },
+				close_pos = { start = { row = 0, col = 4 }, ["end"] = { row = 0, col = 5 } },
+				pair_open = "(",
+				pair_close = ")",
+			},
+		},
+	}
+
+	surround.run(ctx, cfg, ms)
+
+	local lines = helpers.get_buf_lines()
+	expect.equality(lines[1], "foobaz")
+end
+
+T["surround action"]["delete handles curly braces"] = function()
+	local bufnr = helpers.create_buf({ "let x = {value}" })
+	helpers.set_cursor(1, 0)
+
+	local surround = require("smart-motion.actions.surround")
+	local ctx = helpers.build_ctx()
+	local cfg = require("smart-motion.config").validated
+	local ms = {
+		motion = { action_key = "d" },
+		selected_jump_target = {
+			start_pos = { row = 0, col = 8 },
+			end_pos = { row = 0, col = 15 },
+			text = "{value}",
+			metadata = {
+				bufnr = bufnr,
+				is_surround = true,
+				open_pos = { start = { row = 0, col = 8 }, ["end"] = { row = 0, col = 9 } },
+				close_pos = { start = { row = 0, col = 14 }, ["end"] = { row = 0, col = 15 } },
+				pair_open = "{",
+				pair_close = "}",
+			},
+		},
+	}
+
+	surround.run(ctx, cfg, ms)
+
+	local lines = helpers.get_buf_lines()
+	expect.equality(lines[1], "let x = value")
+end
+
+-- =============================================================================
+-- Pairs collector edge cases
+-- =============================================================================
+
+T["pairs collector edge cases"] = MiniTest.new_set()
+
+T["pairs collector edge cases"]["handles empty pairs"] = function()
+	helpers.create_buf({ "foo() bar()" })
+	helpers.set_cursor(1, 0)
+
+	local collector = require("smart-motion.collectors.pairs")
+	local gen = collector.run()
+
+	local ctx = helpers.build_ctx()
+	local cfg = require("smart-motion.config").validated
+	local ms = { pair_chars = { { "(", ")" } } }
+
+	local results = {}
+	local ok, data = coroutine.resume(gen, ctx, cfg, ms)
+	while ok and data do
+		table.insert(results, data)
+		ok, data = coroutine.resume(gen, ctx, cfg, ms)
+	end
+
+	expect.equality(#results >= 2, true)
+	expect.equality(results[1].content_text, "")
+end
+
+T["pairs collector edge cases"]["handles multiline pairs"] = function()
+	helpers.create_buf({ "foo(", "  bar", ")" })
+	helpers.set_cursor(1, 0)
+
+	local collector = require("smart-motion.collectors.pairs")
+	local gen = collector.run()
+
+	local ctx = helpers.build_ctx()
+	local cfg = require("smart-motion.config").validated
+	local ms = { pair_chars = { { "(", ")" } } }
+
+	local results = {}
+	local ok, data = coroutine.resume(gen, ctx, cfg, ms)
+	while ok and data do
+		table.insert(results, data)
+		ok, data = coroutine.resume(gen, ctx, cfg, ms)
+	end
+
+	expect.equality(#results >= 1, true)
+	expect.equality(results[1].open_pos.start.row, 0)
+	expect.equality(results[1].close_pos.start.row, 2)
+end
+
+-- =============================================================================
+-- Registry integration
+-- =============================================================================
+
+T["registry"] = MiniTest.new_set()
+
+T["registry"]["pairs collector is registered"] = function()
+	local registries = require("smart-motion.core.registries"):get()
+	expect.no_equality(registries.collectors.get_by_name("pairs"), nil)
+end
+
+T["registry"]["pairs extractors are registered"] = function()
+	local registries = require("smart-motion.core.registries"):get()
+	expect.no_equality(registries.extractors.get_by_name("pairs_inside"), nil)
+	expect.no_equality(registries.extractors.get_by_name("pairs_around"), nil)
+	expect.no_equality(registries.extractors.get_by_name("pairs_surround"), nil)
+end
+
+T["registry"]["surround action is registered"] = function()
+	local registries = require("smart-motion.core.registries"):get()
+	expect.no_equality(registries.actions.get_by_name("surround"), nil)
+	expect.no_equality(registries.actions.get_by_name("surround_add"), nil)
+	expect.no_equality(registries.actions.get_by_name("surround_paste"), nil)
+end
+
+T["registry"]["PAIRS target type exists"] = function()
+	local consts = require("smart-motion.consts")
+	expect.equality(consts.TARGET_TYPES.PAIRS, "pairs")
+end
+
+-- =============================================================================
+-- Preset registration
+-- =============================================================================
+
+T["surround presets"] = MiniTest.new_set({
+	hooks = {
+		pre_case = function()
+			helpers.setup_plugin({
+				presets = { surround = true },
+			})
+		end,
+		post_case = helpers.cleanup,
+	},
+})
+
+T["surround presets"]["registers ( and ) textobjects"] = function()
+	local motions = require("smart-motion.motions")
+	local to = motions.get_textobject("(")
+	expect.no_equality(to, nil)
+	expect.equality(to.extractor, "pairs")
+	expect.equality(to.collector, "pairs")
+
+	-- ) should also be registered
+	local to2 = motions.get_textobject(")")
+	expect.no_equality(to2, nil)
+	expect.equality(to2.extractor, "pairs")
+end
+
+T["surround presets"]["( textobject has inside/around/surround overrides"] = function()
+	local motions = require("smart-motion.motions")
+	local to = motions.get_textobject("(")
+	expect.equality(to.inside.pair_scope, "inside")
+	expect.equality(to.around.pair_scope, "around")
+	expect.equality(to.surround.pair_scope, "surround")
+	expect.equality(to.surround.is_surround, true)
+end
+
+T["surround presets"]["registers ds/cs surround operators"] = function()
+	local motions = require("smart-motion.motions")
+	local ds = motions.get_by_key("ds")
+	expect.no_equality(ds, nil)
+	expect.equality(ds.infer, true)
+	expect.equality(ds.action, "surround")
+	expect.equality(ds.action_key, "d")
+
+	local cs = motions.get_by_key("cs")
+	expect.no_equality(cs, nil)
+	expect.equality(cs.action_key, "c")
+end
+
+T["surround presets"]["registers bracket pair textobjects"] = function()
+	local motions = require("smart-motion.motions")
+
+	-- Check all bracket types as textobjects
+	for _, pair in ipairs({ { "[", "]" }, { "{", "}" }, { "<", ">" } }) do
+		expect.no_equality(motions.get_textobject(pair[1]), nil)
+		expect.no_equality(motions.get_textobject(pair[2]), nil)
+	end
+end
+
+T["surround presets"]["registers quote pair textobjects"] = function()
+	local motions = require("smart-motion.motions")
+
+	for _, q in ipairs({ '"', "'", "`" }) do
+		expect.no_equality(motions.get_textobject(q), nil)
+	end
+end
+
+T["surround presets"]["( textobject sets pair_chars in metadata"] = function()
+	local motions = require("smart-motion.motions")
+	local to = motions.get_textobject("(")
+	expect.no_equality(to.metadata.motion_state.pair_chars, nil)
+	expect.equality(to.metadata.motion_state.pair_chars[1][1], "(")
+	expect.equality(to.metadata.motion_state.pair_chars[1][2], ")")
+end
+
+T["surround presets"]["( surround overrides set is_surround"] = function()
+	local motions = require("smart-motion.motions")
+	local to = motions.get_textobject("(")
+	expect.equality(to.surround.is_surround, true)
+end
+
+-- =============================================================================
+-- Module loader action override
+-- =============================================================================
+
+T["module loader"] = MiniTest.new_set()
+
+T["module loader"]["explicit motion.action overrides key-based lookup for infer"] = function()
+	local registries = require("smart-motion.core.registries"):get()
+
+	-- Simulate an infer motion with explicit action
+	local module_loader = require("smart-motion.utils.module_loader")
+	local ctx = helpers.build_ctx()
+	local cfg = require("smart-motion.config").validated
+
+	local ms = {
+		motion = {
+			infer = true,
+			action_key = "d",
+			action = "surround",
+			collector = "pairs",
+			extractor = "pairs_surround",
+			filter = "filter_visible",
+			visualizer = "hint_start",
+		},
+	}
+
+	local modules = module_loader.get_modules(ctx, cfg, ms, { "action" })
+	expect.no_equality(modules.action, nil)
+	expect.equality(modules.action.name, "surround")
+end
+
+T["module loader"]["falls back to key-based lookup when no explicit action"] = function()
+	local module_loader = require("smart-motion.utils.module_loader")
+	local ctx = helpers.build_ctx()
+	local cfg = require("smart-motion.config").validated
+
+	local ms = {
+		motion = {
+			infer = true,
+			action_key = "d",
+			collector = "lines",
+			filter = "filter_visible",
+			visualizer = "hint_start",
+		},
+	}
+
+	local modules = module_loader.get_modules(ctx, cfg, ms, { "action" })
+	expect.no_equality(modules.action, nil)
+	-- Should resolve to delete_jump (key "d")
+	expect.equality(modules.action.name, "delete_jump")
+end
+
+T["module loader"]["ys operator keeps surround_add action when composable has no override"] = function()
+	local module_loader = require("smart-motion.utils.module_loader")
+	local ctx = helpers.build_ctx()
+	local cfg = require("smart-motion.config").validated
+
+	-- Simulates ysw: ys operator with action=surround_add,
+	-- composable w did NOT override (no override_action flag)
+	local ms = {
+		motion = {
+			infer = true,
+			action_key = "ys",
+			action = "surround_add",
+			collector = "lines",
+			extractor = "words",
+			filter = "filter_visible",
+			visualizer = "hint_start",
+		},
+	}
+
+	local modules = module_loader.get_modules(ctx, cfg, ms, { "action" })
+	expect.no_equality(modules.action, nil)
+	expect.equality(modules.action.name, "surround_add")
+end
+
+T["module loader"]["dw resolves to delete_jump not jump_centered"] = function()
+	local module_loader = require("smart-motion.utils.module_loader")
+	local ctx = helpers.build_ctx()
+	local cfg = require("smart-motion.config").validated
+
+	-- Simulates dw: d operator, composable w did NOT copy action
+	-- (override_action is not set on w), so motion.action stays nil
+	local ms = {
+		motion = {
+			infer = true,
+			action_key = "d",
+			collector = "lines",
+			extractor = "words",
+			filter = "filter_visible",
+			visualizer = "hint_start",
+			-- action is NOT set (w's action was not copied)
+		},
+	}
+
+	local modules = module_loader.get_modules(ctx, cfg, ms, { "action" })
+	expect.no_equality(modules.action, nil)
+	expect.equality(modules.action.name, "delete_jump")
+end
+
+return T

--- a/tests/test_textobjects.lua
+++ b/tests/test_textobjects.lua
@@ -1,0 +1,490 @@
+local MiniTest = require("mini_test")
+local expect = MiniTest.expect
+local helpers = require("tests.helpers")
+
+local T = MiniTest.new_set({
+	hooks = {
+		pre_case = function()
+			helpers.setup_plugin()
+		end,
+		post_case = helpers.cleanup,
+	},
+})
+
+-- =============================================================================
+-- Textobject Registry
+-- =============================================================================
+
+T["textobject_registry"] = MiniTest.new_set()
+
+T["textobject_registry"]["register and get textobject"] = function()
+	local motions = require("smart-motion.motions")
+
+	motions.register_textobject("x", {
+		collector = "treesitter",
+		extractor = "pass_through",
+		metadata = {
+			label = "Test",
+			motion_state = { test_flag = true },
+		},
+		inside = { test_inside = true },
+		around = { test_around = true },
+		default = "around",
+	})
+
+	local to = motions.get_textobject("x")
+	expect.no_equality(to, nil)
+	expect.equality(to.key, "x")
+	expect.equality(to.collector, "treesitter")
+	expect.equality(to.metadata.label, "Test")
+	expect.equality(to.metadata.motion_state.test_flag, true)
+	expect.equality(to.inside.test_inside, true)
+	expect.equality(to.around.test_around, true)
+	expect.equality(to.default, "around")
+end
+
+T["textobject_registry"]["get returns nil for unregistered key"] = function()
+	local motions = require("smart-motion.motions")
+	expect.equality(motions.get_textobject("Z"), nil)
+end
+
+T["textobject_registry"]["has returns true for registered, false for not"] = function()
+	local motions = require("smart-motion.motions")
+
+	motions.register_textobject("q", {
+		collector = "treesitter",
+		extractor = "pass_through",
+	})
+
+	expect.equality(motions.has_textobject("q"), true)
+	expect.equality(motions.has_textobject("Z"), false)
+end
+
+T["textobject_registry"]["register_many registers multiple textobjects"] = function()
+	local motions = require("smart-motion.motions")
+
+	motions.register_many_textobjects({
+		m = { collector = "treesitter", extractor = "pass_through" },
+		n = { collector = "treesitter", extractor = "pass_through" },
+	})
+
+	expect.equality(motions.has_textobject("m"), true)
+	expect.equality(motions.has_textobject("n"), true)
+end
+
+T["textobject_registry"]["defaults inside and around to empty tables"] = function()
+	local motions = require("smart-motion.motions")
+
+	motions.register_textobject("v", {
+		collector = "treesitter",
+		extractor = "pass_through",
+	})
+
+	local to = motions.get_textobject("v")
+	expect.equality(type(to.inside), "table")
+	expect.equality(type(to.around), "table")
+	expect.equality(to.default, "around")
+end
+
+-- =============================================================================
+-- Key Resolver
+-- =============================================================================
+
+T["key_resolver"] = MiniTest.new_set()
+
+T["key_resolver"]["RESOLVE_TYPE constants exist"] = function()
+	local key_resolver = require("smart-motion.core.key_resolver")
+	expect.equality(key_resolver.RESOLVE_TYPE.TEXTOBJECT, "textobject")
+	expect.equality(key_resolver.RESOLVE_TYPE.COMPOSABLE, "composable")
+	expect.equality(key_resolver.RESOLVE_TYPE.FALLBACK, "fallback")
+end
+
+-- =============================================================================
+-- Treesitter Textobject Registrations
+-- =============================================================================
+
+T["treesitter_textobjects"] = MiniTest.new_set({
+	hooks = {
+		pre_case = function()
+			helpers.setup_plugin({ presets = { treesitter = true } })
+		end,
+		post_case = helpers.cleanup,
+	},
+})
+
+T["treesitter_textobjects"]["f textobject is registered"] = function()
+	local motions = require("smart-motion.motions")
+	local to = motions.get_textobject("f")
+	expect.no_equality(to, nil)
+	expect.equality(to.collector, "treesitter")
+	expect.equality(to.extractor, "pass_through")
+	expect.equality(to.default, "around")
+end
+
+T["treesitter_textobjects"]["f inside sets ts_inner_body"] = function()
+	local motions = require("smart-motion.motions")
+	local to = motions.get_textobject("f")
+	expect.equality(to.inside.ts_inner_body, true)
+end
+
+T["treesitter_textobjects"]["f around has no extra overrides"] = function()
+	local motions = require("smart-motion.motions")
+	local to = motions.get_textobject("f")
+	expect.equality(next(to.around), nil)
+end
+
+T["treesitter_textobjects"]["c textobject is registered for class"] = function()
+	local motions = require("smart-motion.motions")
+	local to = motions.get_textobject("c")
+	expect.no_equality(to, nil)
+	expect.equality(to.collector, "treesitter")
+	expect.equality(to.inside.ts_inner_body, true)
+	expect.equality(to.default, "around")
+end
+
+T["treesitter_textobjects"]["a textobject is registered for argument"] = function()
+	local motions = require("smart-motion.motions")
+	local to = motions.get_textobject("a")
+	expect.no_equality(to, nil)
+	expect.equality(to.collector, "treesitter")
+	expect.equality(to.default, "inside")
+end
+
+T["treesitter_textobjects"]["a around sets ts_around_separator"] = function()
+	local motions = require("smart-motion.motions")
+	local to = motions.get_textobject("a")
+	expect.equality(to.around.ts_around_separator, true)
+end
+
+T["treesitter_textobjects"]["a inside has no extra overrides"] = function()
+	local motions = require("smart-motion.motions")
+	local to = motions.get_textobject("a")
+	expect.equality(next(to.inside), nil)
+end
+
+T["treesitter_textobjects"]["navigation motions still registered as composables"] = function()
+	local motions = require("smart-motion.motions")
+	-- These should still be regular composable motions, NOT textobjects
+	expect.no_equality(motions.get_by_key("]]"), nil)
+	expect.no_equality(motions.get_by_key("[["), nil)
+	expect.no_equality(motions.get_by_key("]c"), nil)
+	expect.no_equality(motions.get_by_key("[c"), nil)
+end
+
+T["treesitter_textobjects"]["fn still registered as composable motion"] = function()
+	local motions = require("smart-motion.motions")
+	local fn = motions.get_composable_by_key("fn")
+	expect.no_equality(fn, nil)
+	expect.equality(fn.collector, "treesitter")
+end
+
+-- =============================================================================
+-- Pair Textobject Registrations
+-- =============================================================================
+
+T["pair_textobjects"] = MiniTest.new_set({
+	hooks = {
+		pre_case = function()
+			helpers.setup_plugin({ presets = { surround = true } })
+		end,
+		post_case = helpers.cleanup,
+	},
+})
+
+T["pair_textobjects"]["( textobject is registered"] = function()
+	local motions = require("smart-motion.motions")
+	local to = motions.get_textobject("(")
+	expect.no_equality(to, nil)
+	expect.equality(to.collector, "pairs")
+	expect.equality(to.extractor, "pairs")
+	expect.equality(to.default, "around")
+end
+
+T["pair_textobjects"]["( inside sets pair_scope to inside"] = function()
+	local motions = require("smart-motion.motions")
+	local to = motions.get_textobject("(")
+	expect.equality(to.inside.pair_scope, "inside")
+end
+
+T["pair_textobjects"]["( around sets pair_scope to around"] = function()
+	local motions = require("smart-motion.motions")
+	local to = motions.get_textobject("(")
+	expect.equality(to.around.pair_scope, "around")
+end
+
+T["pair_textobjects"]["( surround sets pair_scope and is_surround"] = function()
+	local motions = require("smart-motion.motions")
+	local to = motions.get_textobject("(")
+	expect.equality(to.surround.pair_scope, "surround")
+	expect.equality(to.surround.is_surround, true)
+end
+
+T["pair_textobjects"][") textobject is also registered (closing char)"] = function()
+	local motions = require("smart-motion.motions")
+	local to = motions.get_textobject(")")
+	expect.no_equality(to, nil)
+	expect.equality(to.collector, "pairs")
+end
+
+T["pair_textobjects"]["[ and ] textobjects are registered"] = function()
+	local motions = require("smart-motion.motions")
+	expect.no_equality(motions.get_textobject("["), nil)
+	expect.no_equality(motions.get_textobject("]"), nil)
+end
+
+T["pair_textobjects"]["{ and } textobjects are registered"] = function()
+	local motions = require("smart-motion.motions")
+	expect.no_equality(motions.get_textobject("{"), nil)
+	expect.no_equality(motions.get_textobject("}"), nil)
+end
+
+T["pair_textobjects"]["quote textobjects are registered"] = function()
+	local motions = require("smart-motion.motions")
+	expect.no_equality(motions.get_textobject('"'), nil)
+	expect.no_equality(motions.get_textobject("'"), nil)
+	expect.no_equality(motions.get_textobject("`"), nil)
+end
+
+T["pair_textobjects"]["symmetric delimiters register only once (no duplicate)"] = function()
+	local motions = require("smart-motion.motions")
+	-- For symmetric pairs like "", the open and close are the same char
+	local to = motions.get_textobject('"')
+	expect.no_equality(to, nil)
+	expect.equality(to.inside.pair_scope, "inside")
+end
+
+-- =============================================================================
+-- Surround Operators
+-- =============================================================================
+
+T["surround_operators"] = MiniTest.new_set({
+	hooks = {
+		pre_case = function()
+			helpers.setup_plugin({ presets = { surround = true } })
+		end,
+		post_case = helpers.cleanup,
+	},
+})
+
+T["surround_operators"]["ds operator is registered"] = function()
+	local motions = require("smart-motion.motions")
+	local ds = motions.get_by_key("ds")
+	expect.no_equality(ds, nil)
+	expect.equality(ds.infer, true)
+	expect.equality(ds.action, "surround")
+	expect.equality(ds.action_key, "d")
+end
+
+T["surround_operators"]["cs operator is registered"] = function()
+	local motions = require("smart-motion.motions")
+	local cs = motions.get_by_key("cs")
+	expect.no_equality(cs, nil)
+	expect.equality(cs.infer, true)
+	expect.equality(cs.action, "surround")
+	expect.equality(cs.action_key, "c")
+end
+
+T["surround_operators"]["ys operator is registered"] = function()
+	local motions = require("smart-motion.motions")
+	local ys = motions.get_by_key("ys")
+	expect.no_equality(ys, nil)
+	expect.equality(ys.infer, true)
+	expect.equality(ys.action, "surround_add")
+end
+
+T["surround_operators"]["ds has textobject_key = surround in motion_state"] = function()
+	local motions = require("smart-motion.motions")
+	local ds = motions.get_by_key("ds")
+	expect.equality(ds.metadata.motion_state.textobject_key, "surround")
+end
+
+T["surround_operators"]["cs has textobject_key = surround in motion_state"] = function()
+	local motions = require("smart-motion.motions")
+	local cs = motions.get_by_key("cs")
+	expect.equality(cs.metadata.motion_state.textobject_key, "surround")
+end
+
+T["surround_operators"]["ys does NOT have textobject_key pre-set"] = function()
+	local motions = require("smart-motion.motions")
+	local ys = motions.get_by_key("ys")
+	expect.equality(ys.metadata.motion_state.textobject_key, nil)
+end
+
+-- =============================================================================
+-- Backwards Compatibility
+-- =============================================================================
+
+T["backwards_compat"] = MiniTest.new_set({
+	hooks = {
+		pre_case = function()
+			helpers.setup_plugin({ presets = { treesitter = true, surround = true } })
+		end,
+		post_case = helpers.cleanup,
+	},
+})
+
+T["backwards_compat"]["old af/if motions NOT in motion registry (replaced by textobjects)"] = function()
+	local motions = require("smart-motion.motions")
+	-- These should NOT exist as composable motions anymore
+	expect.equality(motions.get_by_key("af"), nil)
+	expect.equality(motions.get_by_key("if"), nil)
+	expect.equality(motions.get_by_key("ac"), nil)
+	expect.equality(motions.get_by_key("ic"), nil)
+	expect.equality(motions.get_by_key("aa"), nil)
+	expect.equality(motions.get_by_key("ia"), nil)
+end
+
+T["backwards_compat"]["old i(/a( motions NOT in motion registry (replaced by textobjects)"] = function()
+	local motions = require("smart-motion.motions")
+	expect.equality(motions.get_by_key("i("), nil)
+	expect.equality(motions.get_by_key("a("), nil)
+	expect.equality(motions.get_by_key("i)"), nil)
+	expect.equality(motions.get_by_key("a)"), nil)
+end
+
+T["backwards_compat"]["old si(/sa( motions NOT in motion registry (replaced by ds/cs)"] = function()
+	local motions = require("smart-motion.motions")
+	expect.equality(motions.get_by_key("si("), nil)
+	expect.equality(motions.get_by_key("sa("), nil)
+end
+
+T["backwards_compat"]["textobject f is accessible"] = function()
+	local motions = require("smart-motion.motions")
+	expect.no_equality(motions.get_textobject("f"), nil)
+end
+
+T["backwards_compat"]["textobject ( is accessible"] = function()
+	local motions = require("smart-motion.motions")
+	expect.no_equality(motions.get_textobject("("), nil)
+end
+
+T["backwards_compat"]["pairs extractor still available (legacy alias)"] = function()
+	local registries = require("smart-motion.core.registries"):get()
+	expect.no_equality(registries.extractors.get_by_name("pairs"), nil)
+	expect.no_equality(registries.extractors.get_by_name("pairs_inside"), nil)
+	expect.no_equality(registries.extractors.get_by_name("pairs_around"), nil)
+	expect.no_equality(registries.extractors.get_by_name("pairs_surround"), nil)
+end
+
+-- =============================================================================
+-- Infer Integration (textobject resolution)
+-- =============================================================================
+
+T["infer_textobject"] = MiniTest.new_set({
+	hooks = {
+		pre_case = function()
+			helpers.setup_plugin({
+				presets = {
+					words = true,
+					delete = true,
+					treesitter = true,
+					surround = true,
+				},
+			})
+		end,
+		post_case = helpers.cleanup,
+	},
+})
+
+T["infer_textobject"]["apply_textobject merges base motion_state"] = function()
+	-- Test the apply_textobject logic by simulating what infer does
+	local motions = require("smart-motion.motions")
+	local to = motions.get_textobject("f")
+
+	-- Verify the textobject has the expected base motion_state
+	expect.no_equality(to.metadata.motion_state.ts_node_types, nil)
+	expect.equality(to.metadata.motion_state.is_textobject, true)
+end
+
+T["infer_textobject"]["apply_textobject merges inside overrides"] = function()
+	local motions = require("smart-motion.motions")
+	local to = motions.get_textobject("f")
+
+	-- Simulate what infer does: merge base + inside overrides
+	local motion_state = {}
+	for k, v in pairs(to.metadata.motion_state) do
+		motion_state[k] = v
+	end
+	for k, v in pairs(to.inside) do
+		motion_state[k] = v
+	end
+
+	expect.equality(motion_state.ts_inner_body, true)
+	expect.equality(motion_state.is_textobject, true)
+end
+
+T["infer_textobject"]["apply_textobject merges around overrides for argument"] = function()
+	local motions = require("smart-motion.motions")
+	local to = motions.get_textobject("a")
+
+	local motion_state = {}
+	for k, v in pairs(to.metadata.motion_state) do
+		motion_state[k] = v
+	end
+	for k, v in pairs(to.around) do
+		motion_state[k] = v
+	end
+
+	expect.equality(motion_state.ts_around_separator, true)
+	expect.equality(motion_state.ts_yield_children, true)
+end
+
+T["infer_textobject"]["apply_textobject merges surround overrides for pair"] = function()
+	local motions = require("smart-motion.motions")
+	local to = motions.get_textobject("(")
+
+	local motion_state = {}
+	for k, v in pairs(to.metadata.motion_state) do
+		motion_state[k] = v
+	end
+	for k, v in pairs(to.surround) do
+		motion_state[k] = v
+	end
+
+	expect.equality(motion_state.pair_scope, "surround")
+	expect.equality(motion_state.is_surround, true)
+	expect.equality(motion_state.is_textobject, true)
+end
+
+T["infer_textobject"]["composable w is still accessible for dw"] = function()
+	local motions = require("smart-motion.motions")
+	local w = motions.get_composable_by_key("w")
+	expect.no_equality(w, nil)
+	expect.equality(w.extractor, "words")
+end
+
+T["infer_textobject"]["d operator still resolves to delete action"] = function()
+	local motions = require("smart-motion.motions")
+	local d = motions.get_by_key("d")
+	expect.no_equality(d, nil)
+	expect.equality(d.infer, true)
+end
+
+-- =============================================================================
+-- Module Loader (action resolution for surround operators)
+-- =============================================================================
+
+T["module_loader"] = MiniTest.new_set({
+	hooks = {
+		pre_case = function()
+			helpers.setup_plugin({ presets = { surround = true, delete = true, words = true } })
+		end,
+		post_case = helpers.cleanup,
+	},
+})
+
+T["module_loader"]["surround action is registered"] = function()
+	local registries = require("smart-motion.core.registries"):get()
+	local surround_action = registries.actions.get_by_name("surround")
+	expect.no_equality(surround_action, nil)
+	expect.equality(type(surround_action.run), "function")
+end
+
+T["module_loader"]["surround_add action is registered"] = function()
+	local registries = require("smart-motion.core.registries"):get()
+	local surround_add = registries.actions.get_by_name("surround_add")
+	expect.no_equality(surround_add, nil)
+	expect.equality(type(surround_add.run), "function")
+end
+
+return T


### PR DESCRIPTION
## Summary

- **Textobject registry**: Separate registry from composable motions with key resolver for `i`/`a` prefix routing. Pattern-based pair detection fallback when treesitter can't parse.
- **Surround operators**: `ds`/`cs`/`ys`/`gza`/`gzp`/visual `S` with configurable padding (`surround_pad`), visual feedback (delimiter/target highlighting), and hint label clearing during prompts.
- **Special surround types**: `q` (any quote), `t` (HTML/XML tags with live multi-cursor rename), `f` (function calls with in-place name editing).
- **Target expansion**: `+`/`-` keys to grow/shrink selection after picking a target. Dim hints on adjacent targets. Zero friction for single-target use.
- **Bug fixes**: undojoin safety, change indentation preservation, module metadata precedence, keyword-only word pattern for surround.

47 files changed, 5366 insertions. 563 tests passing, 0 failures.

## Test plan

- [ ] `di(`/`da(`/`vi(`/`ci"` — pair text objects with labels on all matching pairs
- [ ] `ds(`/`ds)` — delete surround (opening strips padding, closing doesn't)
- [ ] `cs(` — change surround with delimiter highlighting, padding-aware
- [ ] `ysaw(`/`ysaw)` — add surround with/without padding
- [ ] `dsq`/`csq` — quote alias (any type)
- [ ] `dst` — delete surrounding HTML/XML tag
- [ ] `cst` — live multi-cursor tag rename (type in opening, closing syncs real-time)
- [ ] `dsf` — unwrap function call
- [ ] `csf` — in-place function name editing (insert mode)
- [ ] `gza` — standalone surround add with keyword-only word targets
- [ ] `gzp` — paste surround with stored pair
- [ ] Visual `S` — wrap selection with prompted delimiter
- [ ] Target expansion: `ysaw` → pick → `++` → `(` wraps 3 words
- [ ] `+`/`-`/`⌫` hints appear on adjacent targets during expansion
- [ ] `dw`/`yw`/`cw`/`dd`/`yy` — no regression on existing motions
- [ ] `daf`/`dif`/`dac`/`dia` — treesitter text objects unchanged
- [ ] `diw`/`daw` — native Vim fallback for unregistered textobject keys
- [ ] Pattern fallback works on files with broken syntax
- [ ] `presets = { surround = true }` backwards compatible