### PR TITLE
Fix folded line navigation and floating window conflict with opencode.nvim

### DIFF
--- a/lua/smart-motion/actions/history_browse.lua
+++ b/lua/smart-motion/actions/history_browse.lua
@@ -2,6 +2,7 @@
 --- Triggered by `g.`: browse all history entries, pick one to jump back to.
 --- Uses nui.nvim for proper split layout if available, falls back to simple popup.
 local consts = require("smart-motion.consts")
+local utils = require("smart-motion.utils")
 
 local M = {}
 
@@ -656,6 +657,9 @@ function M.run()
 
 	-- Mount layout
 	layout:mount()
+	for _, popup in ipairs({ header_popup, preview_popup, list_popup, hint_popup }) do
+		utils.mark_floating_window(popup.winid)
+	end
 	refresh()
 
 	-- Cleanup

--- a/lua/smart-motion/actions/jump.lua
+++ b/lua/smart-motion/actions/jump.lua
@@ -86,10 +86,6 @@ function M.run(ctx, cfg, motion_state)
 		return
 	end
 
-	-- Open any folds at the target position
-	if not is_op_pending then
-		vim.cmd("normal! zv")
-	end
 
 	log.debug(string.format("Cursor moved to line %d, col %d", row, col))
 end

--- a/lua/smart-motion/collectors/lines.lua
+++ b/lua/smart-motion/collectors/lines.lua
@@ -31,8 +31,11 @@ function M.run()
 			-- foldclosed() returns -1 if line is not in a fold, otherwise returns the first line of the fold
 			if vim.fn.foldclosed(line_number + 1) ~= -1 then
 				-- Line is inside a closed fold, skip to the line after the fold
-				-- foldclosedend() returns 1-based line number of last line in fold
-				-- Since our line_number is 0-based, foldclosedend() directly gives us the next 0-based index
+				-- foldclosedend() returns the 1-based line number of the last line in the fold
+				-- When we set line_number to this value, we're setting it to what will be
+				-- the 0-based index of the first line AFTER the fold in the next iteration
+				-- Example: fold on 1-based lines 10-20 → foldclosedend returns 20 → 
+				-- line_number becomes 20 (0-based) which is 1-based line 21 (after fold)
 				line_number = vim.fn.foldclosedend(line_number + 1)
 			else
 				-- Line is visible (not in a closed fold), collect it

--- a/lua/smart-motion/collectors/lines.lua
+++ b/lua/smart-motion/collectors/lines.lua
@@ -30,7 +30,6 @@ function M.run()
 			-- where a fold counts as a single line but is still jumpable
 			-- foldclosed() returns -1 if line is not in a fold, otherwise returns the first line of the fold
 			local fold_start = vim.fn.foldclosed(line_number + 1)
-			
 			if fold_start ~= -1 then
 				-- Line is inside a closed fold
 				-- Check if this is the FIRST line of the fold

--- a/lua/smart-motion/collectors/lines.lua
+++ b/lua/smart-motion/collectors/lines.lua
@@ -32,10 +32,11 @@ function M.run()
 			if vim.fn.foldclosed(line_number + 1) ~= -1 then
 				-- Line is inside a closed fold, skip to the line after the fold
 				-- foldclosedend() returns the 1-based line number of the last line in the fold
-				-- When we set line_number to this value, we're setting it to what will be
-				-- the 0-based index of the first line AFTER the fold in the next iteration
-				-- Example: fold on 1-based lines 10-20 → foldclosedend returns 20 → 
-				-- line_number becomes 20 (0-based) which is 1-based line 21 (after fold)
+				-- Setting line_number to this value skips past the fold because:
+				-- Example: fold on 1-based lines 10-20
+				--   foldclosedend(10) returns 20
+				--   line_number = 20 (interpreting as 0-based index)
+				--   Next iteration: foldclosed(20+1) = foldclosed(21) checks 1-based line 21 (after fold)
 				line_number = vim.fn.foldclosedend(line_number + 1)
 			else
 				-- Line is visible (not in a closed fold), collect it

--- a/lua/smart-motion/collectors/lines.lua
+++ b/lua/smart-motion/collectors/lines.lua
@@ -29,11 +29,11 @@ function M.run()
 			-- Skip lines inside closed folds to match Neovim's native j/k behavior
 			-- where a fold counts as a single line
 			-- foldclosed() returns -1 if line is not in a fold, otherwise returns the first line of the fold
-			local fold_start = vim.fn.foldclosed(line_number + 1)
-			if fold_start ~= -1 then
-				-- Line is inside a closed fold, skip to the end of the fold
-				local fold_end = vim.fn.foldclosedend(line_number + 1)
-				line_number = fold_end  -- Skip to end of fold (1-based), will be converted back to 0-based
+			if vim.fn.foldclosed(line_number + 1) ~= -1 then
+				-- Line is inside a closed fold, skip to the line after the fold
+				-- foldclosedend() returns 1-based line number of last line in fold
+				-- Since our line_number is 0-based, foldclosedend() directly gives us the next 0-based index
+				line_number = vim.fn.foldclosedend(line_number + 1)
 			else
 				-- Line is visible (not in a closed fold), collect it
 				local line = vim.api.nvim_buf_get_lines(ctx.bufnr, line_number, line_number + 1, false)[1]

--- a/lua/smart-motion/collectors/lines.lua
+++ b/lua/smart-motion/collectors/lines.lua
@@ -26,17 +26,26 @@ function M.run()
 
 		local line_number = start_line
 		while line_number <= end_line do
-			-- Skip lines inside closed folds to match Neovim's native j/k behavior
-			-- where a fold counts as a single line
+			-- Handle closed folds to match Neovim's native j/k behavior
+			-- where a fold counts as a single line but is still jumpable
 			-- foldclosed() returns -1 if line is not in a fold, otherwise returns the first line of the fold
-			if vim.fn.foldclosed(line_number + 1) ~= -1 then
-				-- Line is inside a closed fold, skip to the line after the fold
+			local fold_start = vim.fn.foldclosed(line_number + 1)
+			
+			if fold_start ~= -1 then
+				-- Line is inside a closed fold
+				-- Check if this is the FIRST line of the fold
+				if fold_start == line_number + 1 then
+					-- This is the first line of the fold, yield it so we can jump to it
+					local line = vim.api.nvim_buf_get_lines(ctx.bufnr, line_number, line_number + 1, false)[1]
+					if line then
+						coroutine.yield({
+							line_number = line_number,
+							text = line,
+						})
+					end
+				end
+				-- Skip to the line after the fold (whether we yielded it or not)
 				-- foldclosedend() returns the 1-based line number of the last line in the fold
-				-- Setting line_number to this value skips past the fold because:
-				-- Example: fold on 1-based lines 10-20
-				--   foldclosedend(10) returns 20
-				--   line_number = 20 (interpreting as 0-based index)
-				--   Next iteration: foldclosed(20+1) = foldclosed(21) checks 1-based line 21 (after fold)
 				line_number = vim.fn.foldclosedend(line_number + 1)
 			else
 				-- Line is visible (not in a closed fold), collect it

--- a/lua/smart-motion/collectors/lines.lua
+++ b/lua/smart-motion/collectors/lines.lua
@@ -25,13 +25,18 @@ function M.run()
 		local end_line = math.min(total_lines - 1, cursor_line + window_size)
 
 		for line_number = start_line, end_line do
-			local line = vim.api.nvim_buf_get_lines(ctx.bufnr, line_number, line_number + 1, false)[1]
+			-- Skip lines inside closed folds to match Neovim's native j/k behavior
+			-- where a fold counts as a single line
+			local fold_start = vim.fn.foldclosed(line_number + 1)
+			if fold_start == -1 then
+				local line = vim.api.nvim_buf_get_lines(ctx.bufnr, line_number, line_number + 1, false)[1]
 
-			if line then
-				coroutine.yield({
-					line_number = line_number,
-					text = line,
-				})
+				if line then
+					coroutine.yield({
+						line_number = line_number,
+						text = line,
+					})
+				end
 			end
 		end
 	end)

--- a/lua/smart-motion/utils.lua
+++ b/lua/smart-motion/utils.lua
@@ -9,12 +9,23 @@ local history = require("smart-motion.core.history")
 local exit = require("smart-motion.core.events.exit")
 
 local EXIT_TYPE = consts.EXIT_TYPE
+local FLOAT_WINDOW_OWNER_VAR = "smart_motion_owned"
 
 local M = {}
 
---- Closes all diagnostic and completion floating windows.
+--- Marks a window as being owned by smart-motion.
+---@param winid integer
+function M.mark_floating_window(winid)
+	if not vim.api.nvim_win_is_valid(winid) then
+		return
+	end
+
+	pcall(vim.api.nvim_win_set_var, winid, FLOAT_WINDOW_OWNER_VAR, true)
+end
+
+--- Closes floating windows created by smart-motion.
 function M.close_floating_windows()
-	log.debug("Closing floating windows (diagnostics & completion)")
+	log.debug("Closing smart-motion floating windows")
 
 	for _, winid in ipairs(vim.api.nvim_list_wins()) do
 		local ok, win_config = pcall(vim.api.nvim_win_get_config, winid)
@@ -25,7 +36,9 @@ function M.close_floating_windows()
 			goto continue
 		end
 
-		if vim.tbl_contains({ "cursor", "win" }, win_config.relative) then
+		local has_owner_var, owned = pcall(vim.api.nvim_win_get_var, winid, FLOAT_WINDOW_OWNER_VAR)
+
+		if has_owner_var and owned and win_config.relative ~= "" then
 			local success, err = pcall(vim.api.nvim_win_close, winid, true)
 
 			if not success then

--- a/tests/test_utils.lua
+++ b/tests/test_utils.lua
@@ -84,6 +84,44 @@ T["prepare_motion"]["returns ctx, cfg, and motion_state"] = function()
 end
 
 -- =============================================================================
+-- close_floating_windows
+-- =============================================================================
+
+T["close_floating_windows"] = MiniTest.new_set()
+
+T["close_floating_windows"]["closes only smart-motion owned floating windows"] = function()
+	helpers.create_buf({ "test" })
+
+	local utils = require("smart-motion.utils")
+	local owned_buf = vim.api.nvim_create_buf(false, true)
+	local foreign_buf = vim.api.nvim_create_buf(false, true)
+
+	local owned_win = vim.api.nvim_open_win(owned_buf, false, {
+		relative = "editor",
+		row = 1,
+		col = 1,
+		width = 10,
+		height = 1,
+		style = "minimal",
+	})
+	local foreign_win = vim.api.nvim_open_win(foreign_buf, false, {
+		relative = "editor",
+		row = 3,
+		col = 1,
+		width = 10,
+		height = 1,
+		style = "minimal",
+	})
+
+	vim.api.nvim_win_set_var(owned_win, "smart_motion_owned", true)
+
+	utils.close_floating_windows()
+
+	expect.equality(vim.api.nvim_win_is_valid(owned_win), false)
+	expect.equality(vim.api.nvim_win_is_valid(foreign_win), true)
+end
+
+-- =============================================================================
 -- module_wrapper
 -- =============================================================================
 


### PR DESCRIPTION
This PR includes two main improvements:

- It fixes motion behavior around folded lines, so navigation now handles closed folds correctly and behaves more consistently with Neovim’s native movement.
- It resolves conflicts with opencode.nvim by ensuring smart-motion only closes its own floating windows instead of affecting floating windows created by other plugins.